### PR TITLE
fix: 상품기획전, 상품기획전이미지리스트, 상품태그 엔티티 수정

### DIFF
--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductPromotion.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductPromotion.java
@@ -20,12 +20,11 @@ import lombok.ToString;
 public class ProductPromotion {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "promotion_id")
-	private Long promotionId;
-	@Column(name = "promotion_name", nullable = false, length = 255)
+	private Long id;
+	@Column(nullable = false, length = 255)
 	private String promotionName;
-	@Column(name = "promotion_state", nullable = false)
+	@Column(nullable = false)
 	private boolean promotionState;
-	@Column(name = "promotion_info_content", columnDefinition = "TEXT")
+	@Column(columnDefinition = "TEXT")
 	private String promotionInfoContent;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductPromotionImgList.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductPromotionImgList.java
@@ -1,11 +1,13 @@
 package starbucks3355.starbucksServer.domainProduct.entity;
 
-import jakarta.persistence.Column;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,14 +19,13 @@ import lombok.ToString;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
+@ToString(exclude = "promotionId")
 public class ProductPromotionImgList {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "promotion_img_id")
-	private Long promotionImgId;
+	private Long id;
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
 	@JoinColumn(name = "promotion_id", nullable = false)
-	private Long promotionId;
-	@Column(name = "img_path")
+	private ProductPromotion promotionId;
 	private String imgPath;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductTag.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductTag.java
@@ -20,10 +20,8 @@ import lombok.ToString;
 public class ProductTag {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "tag_id")
-	private Long tagId;
-	@Column(length = 255, name = "tag_name")
+	private Long id;
+	@Column(length = 255)
 	private String tagName;
-	@Column(name = "product_code")
 	private Long productCode;
 }


### PR DESCRIPTION
1. Hibernate는 엔티티의 카멜 케이스(CamelCase) 이름을 언더스코어(_)를 이용한 스네이크 케이스(snake_case) 형식의 컬럼명으로 자동으로 변환하기에 @Column의 name 속성을 제거
2. 비식별 연관 테이블들에 대해 @ManyToOne과 @JoinColumn을 통한 연결
3. ProductPromotionImgList의 Long promotionId 필드는 타입이 Long이 아니라 ProductPromotion이어야 함


추가적으로 수정사항 없는지 확인 부탁드립니다.