### PR TITLE
Feature/#26

### DIFF
--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
@@ -47,10 +47,10 @@ public class ProductController {
 	@GetMapping("/productImage/{productCode}")
 	@Operation(summary = "상품 대표 이미지 조회")
 	public CommonResponseEntity<ProductImgResponseVo> getProductImage(
-		@PathVariable Long productCode) {
+		@PathVariable String productUuid) {
 		// productCode는 상품의 PK(Product entity의 id값)를 지칭
 		// Q. 프론트 단에서 url에 상품의id값을 지정하여 요청하는 방식으로 상품에 대한 대표 이미지 추출
-		ProductImgResponseDto productImgResponseDto = productService.getImage(productCode);
+		ProductImgResponseDto productImgResponseDto = productService.getImage(productUuid);
 		// productService.getImage: 상품id값을 기준으로 상품이미지엔티티에서 를 추출하는 로직
 
 		return new CommonResponseEntity<>(

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
@@ -15,8 +15,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import starbucks3355.starbucksServer.common.entity.CommonResponseEntity;
 import starbucks3355.starbucksServer.common.entity.CommonResponseMessage;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductImgResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 import starbucks3355.starbucksServer.domainProduct.service.ProductService;
+import starbucks3355.starbucksServer.domainProduct.vo.response.ProductDetailsResponseVo;
+import starbucks3355.starbucksServer.domainProduct.vo.response.ProductImgResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductResponseVo;
 
 @Slf4j
@@ -37,6 +41,35 @@ public class ProductController {
 			HttpStatus.OK,
 			CommonResponseMessage.SUCCESS.getMessage(),
 			productResponseDto.dtoToResponseVo()
+		);
+	}
+
+	@GetMapping("/productImage/{productCode}")
+	@Operation(summary = "상품 대표 이미지 조회")
+	public CommonResponseEntity<ProductImgResponseVo> getProductImage(
+		@PathVariable Long productCode) {
+		// productCode는 상품의 PK(Product entity의 id값)를 지칭
+		// Q. 프론트 단에서 url에 상품의id값을 지정하여 요청하는 방식으로 상품에 대한 대표 이미지 추출
+		ProductImgResponseDto productImgResponseDto = productService.getImage(productCode);
+		// productService.getImage: 상품id값을 기준으로 상품이미지엔티티에서 를 추출하는 로직
+
+		return new CommonResponseEntity<>(
+			HttpStatus.OK,
+			CommonResponseMessage.SUCCESS.getMessage(),
+			productImgResponseDto.dtoToResponseVo()
+		);
+	}
+
+	@GetMapping("/productDetails/{productUuid}")
+	@Operation(summary = "상품 상세정보 조회")
+	public CommonResponseEntity<ProductDetailsResponseVo> getProductDetails(
+		@PathVariable String productUuid) {
+		ProductDetailsResponseDto productDetails = productService.getProductDetails(productUuid);
+
+		return new CommonResponseEntity<>(
+			HttpStatus.OK,
+			CommonResponseMessage.SUCCESS.getMessage(),
+			productDetails.dtoToResponseVo()
 		);
 	}
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/DiscountResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/DiscountResponseDto.java
@@ -1,7 +1,11 @@
 package starbucks3355.starbucksServer.domainProduct.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
 import starbucks3355.starbucksServer.domainProduct.entity.DiscountType;
 
+@Getter
+@Builder
 public class DiscountResponseDto {
 	private DiscountType discountType;
 	private Integer value;

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/DiscountResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/DiscountResponseDto.java
@@ -1,0 +1,8 @@
+package starbucks3355.starbucksServer.domainProduct.dto.response;
+
+import starbucks3355.starbucksServer.domainProduct.entity.DiscountType;
+
+public class DiscountResponseDto {
+	private DiscountType discountType;
+	private Integer value;
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductDetailsResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductDetailsResponseDto.java
@@ -7,17 +7,17 @@ import starbucks3355.starbucksServer.domainProduct.vo.response.ProductDetailsRes
 @Getter
 @Builder
 public class ProductDetailsResponseDto {
-	private Long productCode; // 상품 옵션의 id 필드의 값을 뜻함
+	private String productUuid; // 상품에 대한 상세정보 엔티티로 접근 하기 위한 필드
 	private Integer price;
 
-	public ProductDetailsResponseDto(Long productCode, Integer price) {
-		this.productCode = productCode;
+	public ProductDetailsResponseDto(String productUuid, Integer price) {
+		this.productUuid = productUuid;
 		this.price = price;
 	}
 
 	public ProductDetailsResponseVo dtoToResponseVo() {
 		return ProductDetailsResponseVo.builder()
-			.productCode(productCode)
+			.productUuid(productUuid)
 			.price(price)
 			.build();
 	}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductDetailsResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductDetailsResponseDto.java
@@ -1,7 +1,11 @@
 package starbucks3355.starbucksServer.domainProduct.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductDetailsResponseVo;
 
+@Getter
+@Builder
 public class ProductDetailsResponseDto {
 	private Long productCode; // 상품 옵션의 id 필드의 값을 뜻함
 	private Integer price;

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductDetailsResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductDetailsResponseDto.java
@@ -1,0 +1,20 @@
+package starbucks3355.starbucksServer.domainProduct.dto.response;
+
+import starbucks3355.starbucksServer.domainProduct.vo.response.ProductDetailsResponseVo;
+
+public class ProductDetailsResponseDto {
+	private Long productCode; // 상품 옵션의 id 필드의 값을 뜻함
+	private Integer price;
+
+	public ProductDetailsResponseDto(Long productCode, Integer price) {
+		this.productCode = productCode;
+		this.price = price;
+	}
+
+	public ProductDetailsResponseVo dtoToResponseVo() {
+		return ProductDetailsResponseVo.builder()
+			.productCode(productCode)
+			.price(price)
+			.build();
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductFlagsResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductFlagsResponseDto.java
@@ -1,0 +1,23 @@
+package starbucks3355.starbucksServer.domainProduct.dto.response;
+
+import starbucks3355.starbucksServer.domainProduct.vo.response.ProductFlagsResponseVo;
+
+public class ProductFlagsResponseDto {
+	private Boolean isLiked;
+	private Boolean isNew;
+	private Boolean isBest;
+
+	public ProductFlagsResponseDto(Boolean isLiked, Boolean isNew, Boolean isBest) {
+		this.isLiked = isLiked;
+		this.isNew = isNew;
+		this.isBest = isBest;
+	}
+
+	public ProductFlagsResponseVo dtoToResponseVo() {
+		return ProductFlagsResponseVo.builder()
+			.isLiked(isLiked)
+			.isBest(isBest)
+			.isNew(isNew)
+			.build();
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductFlagsResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductFlagsResponseDto.java
@@ -1,7 +1,11 @@
 package starbucks3355.starbucksServer.domainProduct.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductFlagsResponseVo;
 
+@Getter
+@Builder
 public class ProductFlagsResponseDto {
 	private Boolean isLiked;
 	private Boolean isNew;

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductImgResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductImgResponseDto.java
@@ -1,7 +1,11 @@
 package starbucks3355.starbucksServer.domainProduct.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductImgResponseVo;
 
+@Getter
+@Builder
 public class ProductImgResponseDto {
 	private String productImgUrl;
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductImgResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductImgResponseDto.java
@@ -1,0 +1,17 @@
+package starbucks3355.starbucksServer.domainProduct.dto.response;
+
+import starbucks3355.starbucksServer.domainProduct.vo.response.ProductImgResponseVo;
+
+public class ProductImgResponseDto {
+	private String productImgUrl;
+
+	public ProductImgResponseDto(String productImgUrl) {
+		this.productImgUrl = productImgUrl;
+	}
+
+	public ProductImgResponseVo dtoToResponseVo() {
+		return ProductImgResponseVo.builder()
+			.productImgUrl(productImgUrl)
+			.build();
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductResponseDto.java
@@ -2,45 +2,27 @@ package starbucks3355.starbucksServer.domainProduct.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import starbucks3355.starbucksServer.domainProduct.entity.DiscountType;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductResponseVo;
 
 @Getter
+@Builder
 public class ProductResponseDto {
 	private String productUuid;
 	private String productName;
 	private String productDescription;
 	private String productInfo;
-	private Long productCode; // 상품 옵션의 id 필드의 값을 뜻함
-	private Integer price;
-	private DiscountType discountType;
-	private Integer value;
-	private String productImg;
-	private Double reviewScore;
-	private Integer reviewCount;
-	private Boolean isLiked;
-	private Boolean isNew;
-	private Boolean isBest;
 
-	@Builder
-	public ProductResponseDto(String productUuid, String productName, String productDescription, String productInfo,
-		Long productCode, Integer price, DiscountType discountType, Integer value, String productImg, Double reviewScore
-		, Integer reviewCount, Boolean isLiked, Boolean isNew, Boolean isBest
+	public ProductResponseDto(
+		String productUuid,
+		String productName,
+		String productDescription,
+		String productInfo
 	) {
 		this.productUuid = productUuid;
 		this.productName = productName;
 		this.productDescription = productDescription;
 		this.productInfo = productInfo;
-		this.productCode = productCode;
-		this.price = price;
-		this.discountType = discountType;
-		this.value = value;
-		this.productImg = productImg;
-		this.reviewScore = reviewScore;
-		this.reviewCount = reviewCount;
-		this.isLiked = isLiked;
-		this.isNew = isNew;
-		this.isBest = isBest;
+
 	}
 
 	public ProductResponseVo dtoToResponseVo() {
@@ -49,16 +31,6 @@ public class ProductResponseDto {
 			.productName(productName)
 			.productDescription(productDescription)
 			.productInfo(productInfo)
-			.productCode(productCode)
-			.price(price)
-			.discountType(discountType)
-			.value(value)
-			.productImg(productImg)
-			.reviewScore(reviewScore)
-			.reviewCount(reviewCount)
-			.isLiked(isLiked)
-			.isNew(isNew)
-			.isBest(isBest)
 			.build();
 	}
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ReviewResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ReviewResponseDto.java
@@ -1,0 +1,20 @@
+package starbucks3355.starbucksServer.domainProduct.dto.response;
+
+import starbucks3355.starbucksServer.domainProduct.vo.response.ReviewResponseVo;
+
+public class ReviewResponseDto {
+	private Double reviewScore;
+	private Integer reviewCount;
+
+	public ReviewResponseDto(Double reviewScore, Integer reviewCount) {
+		this.reviewScore = reviewScore;
+		this.reviewCount = reviewCount;
+	}
+
+	public ReviewResponseVo dtoToResponseVo() {
+		return ReviewResponseVo.builder()
+			.reviewScore(reviewScore)
+			.reviewCount(reviewCount)
+			.build();
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ReviewResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ReviewResponseDto.java
@@ -1,7 +1,11 @@
 package starbucks3355.starbucksServer.domainProduct.dto.response;
 
+import lombok.Builder;
+import lombok.Getter;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ReviewResponseVo;
 
+@Getter
+@Builder
 public class ReviewResponseDto {
 	private Double reviewScore;
 	private Integer reviewCount;

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductDetails.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductDetails.java
@@ -31,6 +31,8 @@ public class ProductDetails {
 	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
 	@JoinColumn(name = "color_id")
 	private ProductSize productColor;
+	@Column(nullable = false, length = 100)
+	private String productUuid;
 	private Boolean isEngraving;
 	private String engravingMessage;
 	@Column(nullable = false)

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
@@ -27,5 +27,5 @@ public class ProductFlags {
 	@Column(nullable = false)
 	private boolean isBest;
 	@Column(nullable = false)
-	private Long productCode;
+	private String productUuid;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
@@ -1,9 +1,21 @@
 package starbucks3355.starbucksServer.domainProduct.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class ProductFlags {
 	@Id
 	@GeneratedValue

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
@@ -1,0 +1,19 @@
+package starbucks3355.starbucksServer.domainProduct.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+public class ProductFlags {
+	@Id
+	@GeneratedValue
+	private Long id;
+	@Column(nullable = false)
+	private boolean isLiked;
+	@Column(nullable = false)
+	private boolean isNew;
+	@Column(nullable = false)
+	private boolean isBest;
+	@Column(nullable = false)
+	private Long productCode;
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductImage.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductImage.java
@@ -27,5 +27,7 @@ public class ProductImage {
 	private String s3Url; // S3에 저장된 이미지 URL
 	@Column(length = 250)
 	private String thumbnailPath;
-	
+	@Column(nullable = false)
+	private Long productCode;
+
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductImage.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductImage.java
@@ -28,6 +28,6 @@ public class ProductImage {
 	@Column(length = 250)
 	private String thumbnailPath;
 	@Column(nullable = false)
-	private Long productCode;
+	private String productUuid;
 
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductImageList.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductImageList.java
@@ -27,7 +27,7 @@ public class ProductImageList {
 	private Long id;
 	private String thumbnailPath;
 	@Column(nullable = false)
-	private Long productCode;
+	private String productUuid;
 	@Column(nullable = false, length = 255)
 	private String productDetailImgPath;
 	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductPromotion.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductPromotion.java
@@ -27,4 +27,6 @@ public class ProductPromotion {
 	private Boolean isState;
 	@Column(columnDefinition = "TEXT")
 	private String promotionInfoContent;
+	@Column(nullable = false)
+	private Long productCode;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/FlagsRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/FlagsRepository.java
@@ -1,0 +1,13 @@
+package starbucks3355.starbucksServer.domainProduct.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import starbucks3355.starbucksServer.domainProduct.entity.ProductFlags;
+
+@Repository
+public interface FlagsRepository extends JpaRepository<ProductFlags, Long> {
+	Optional<ProductFlags> findByProductCode(Long productCode);
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/FlagsRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/FlagsRepository.java
@@ -9,5 +9,5 @@ import starbucks3355.starbucksServer.domainProduct.entity.ProductFlags;
 
 @Repository
 public interface FlagsRepository extends JpaRepository<ProductFlags, Long> {
-	Optional<ProductFlags> findByProductCode(Long productCode);
+	Optional<ProductFlags> findByProductUuid(String productUuid);
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ImageRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ImageRepository.java
@@ -9,5 +9,6 @@ import starbucks3355.starbucksServer.domainProduct.entity.ProductImage;
 
 @Repository
 public interface ImageRepository extends JpaRepository<ProductImage, Long> {
-	Optional<ProductImage> findByProductCode(Long productCode);
+	Optional<ProductImage> findByProductUuid(String productUuid);
+	// Q. 이미지리스트를 불러오고 그 중 대표이미지라는 컬럼값이 true 인 경우를 뽑아내는식으로 가야 하는지?
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ImageRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ImageRepository.java
@@ -1,5 +1,7 @@
 package starbucks3355.starbucksServer.domainProduct.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import starbucks3355.starbucksServer.domainProduct.entity.ProductImage;
 
 @Repository
 public interface ImageRepository extends JpaRepository<ProductImage, Long> {
+	Optional<ProductImage> findByProductCode(Long productCode);
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductDetailsRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductDetailsRepository.java
@@ -1,5 +1,7 @@
 package starbucks3355.starbucksServer.domainProduct.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +9,6 @@ import starbucks3355.starbucksServer.domainProduct.entity.ProductDetails;
 
 @Repository
 public interface ProductDetailsRepository extends JpaRepository<ProductDetails, Long> {
+	Optional<ProductDetails> findByProductUuid(String productUuid);
 
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
@@ -3,6 +3,10 @@ package starbucks3355.starbucksServer.domainProduct.service;
 import java.util.List;
 
 import starbucks3355.starbucksServer.domainProduct.dto.request.ProductRequestDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductFlagsResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductImgResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 
 public interface ProductService {
@@ -10,7 +14,15 @@ public interface ProductService {
 
 	public List<ProductResponseDto> getProducts();
 
-	ProductResponseDto getProduct(String productUuid);
+	public ProductResponseDto getProduct(String productUuid);
+
+	public ProductImgResponseDto getImage(Long productCode);
+
+	public ProductDetailsResponseDto getProductDetails(Long productCode);
+
+	public ProductFlagsResponseDto getProductFlags(Long productCode);
+
+	public DiscountResponseDto getDiscountInfo(Long productCode);
 
 	public void updateProduct(ProductRequestDto productRequestDto);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
@@ -18,7 +18,7 @@ public interface ProductService {
 
 	public ProductImgResponseDto getImage(Long productCode);
 
-	public ProductDetailsResponseDto getProductDetails(Long productCode);
+	public ProductDetailsResponseDto getProductDetails(String productUuid);
 
 	public ProductFlagsResponseDto getProductFlags(Long productCode);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
@@ -16,11 +16,11 @@ public interface ProductService {
 
 	public ProductResponseDto getProduct(String productUuid);
 
-	public ProductImgResponseDto getImage(Long productCode);
+	public ProductImgResponseDto getImage(String productUuid);
 
 	public ProductDetailsResponseDto getProductDetails(String productUuid);
 
-	public ProductFlagsResponseDto getProductFlags(Long productCode);
+	public ProductFlagsResponseDto getProductFlags(String productUuid);
 
 	public DiscountResponseDto getDiscountInfo(Long productCode);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
@@ -82,9 +82,9 @@ public class ProductServiceImpl implements ProductService {
 
 	// Q1.5 아래와 같이 쪼개어 생성된 getXXX 메서드들 만큼 Controller에는 @GetMapping으로 따로 처리하면 되는지?
 	@Override
-	public ProductImgResponseDto getImage(Long productCode) {
+	public ProductImgResponseDto getImage(String productUuid) {
 
-		ProductImage productImage = imgRepository.findByProductCode(productCode)
+		ProductImage productImage = imgRepository.findByProductUuid(productUuid)
 			.orElseThrow(() -> new IllegalArgumentException("해당 이미지가 존재하지 않습니다."));
 		return ProductImgResponseDto.builder()
 			.productImgUrl(productImage.getS3Url())
@@ -104,10 +104,10 @@ public class ProductServiceImpl implements ProductService {
 	}
 
 	@Override
-	public ProductFlagsResponseDto getProductFlags(Long productCode) {
+	public ProductFlagsResponseDto getProductFlags(String productUuid) {
 		// Q2. 여기는 상품에 대해 찜하기여부, 최신상품여부, 베스트 여부
 		// 단순 Boolean 처리이니, 위 3가지 필드에 대해 짬하기 나 베스트 등의 구현에 대해 신경쓰지 말고 새로 엔티티 생성할지?
-		ProductFlags productFlags = flagsRepository.findByProductCode(productCode)
+		ProductFlags productFlags = flagsRepository.findByProductUuid(productUuid)
 			.orElseThrow(() -> new IllegalArgumentException("해당 상품정보가 존재하지 않습니다."));
 
 		return ProductFlagsResponseDto.builder()

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
@@ -9,12 +9,15 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import starbucks3355.starbucksServer.domainProduct.dto.request.ProductRequestDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductFlagsResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductImgResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 import starbucks3355.starbucksServer.domainProduct.entity.Product;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDefaultDisCount;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDetails;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductImage;
-import starbucks3355.starbucksServer.domainProduct.entity.Review;
 import starbucks3355.starbucksServer.domainProduct.repository.DiscountRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ImageRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductDetailsRepository;
@@ -57,41 +60,63 @@ public class ProductServiceImpl implements ProductService {
 	@Override
 	public ProductResponseDto getProduct(String productUuid) {
 
+		// Q0. 아래의 Mock uuid에 대해 컨트롤러에서 여러 서비스에 대해 uuid, id값을 줘야되니 컨트롤러에서 생성하는게 맞는건지?
 		String memberUuid;
 		memberUuid = UUID.randomUUID().toString(); // Member entity 목데이터
 
 		Product product = productRepository.findByProductUuid(productUuid)
 			.orElseThrow(() -> new IllegalArgumentException("해당 상품이 존재하지 않습니다."));
 
-		ProductDetails details = productDetailsRepository.findById(
-			product.getId()).orElseThrow(() -> new IllegalArgumentException("해당 상품정보가 존재하지 않습니다."));
+		// Q1. 리뷰에 대해서는 따로 Service 파일을 생성할지?
+		// Review review = reviewRepository.findByMemberUuidAndProductCode(
+		// 	memberUuid, product.getId()).orElseThrow(() -> new IllegalArgumentException("해당 리뷰가 존재하지 않습니다."));
 
-		ProductDefaultDisCount productDiscount = discountRepository.findById(
-			product.getId()).orElseThrow(() -> new IllegalArgumentException("해당 할인타입이 존재하지 않습니다."));
-
-		ProductImage productImage = imgRepository.findById(
-			product.getId()).orElseThrow(() -> new IllegalArgumentException("해당 이미지가 존재하지 않습니다."));
-
-		Review review = reviewRepository.findByMemberUuidAndProductCode(
-			memberUuid, product.getId()).orElseThrow(() -> new IllegalArgumentException("해당 리뷰가 존재하지 않습니다."));
-
-		int mockReviewCount = 999;
+		// int mockReviewCount = 999;
 
 		return ProductResponseDto.builder()
 			.productUuid(product.getProductUuid())
 			.productName(product.getProductName())
 			.productDescription(product.getProductDescription())
 			.productInfo(product.getProductInfo())
-			.productCode(product.getId())
-			.price(details.getProductPrice())
-			.discountType(productDiscount.getDiscountType())
-			.value(productDiscount.getValue())
-			.productImg(productImage.getS3Url())
-			.reviewScore(review.getScore())
-			.reviewCount(mockReviewCount)
-			.isLiked(true)
-			.isBest(true)
-			.isNew(true)
+			.build();
+	}
+
+	// Q1.5 아래와 같이 쪼개어 생성된 getXXX 메서드들 만큼 Controller에는 @GetMapping으로 따로 처리하면 되는지?
+	@Override
+	public ProductImgResponseDto getImage(Long productCode) {
+		ProductImage productImage = imgRepository.findById(productCode)
+			.orElseThrow(() -> new IllegalArgumentException("해당 이미지가 존재하지 않습니다."));
+		return ProductImgResponseDto.builder()
+			.productImgUrl(productImage.getS3Url())
+			.build();
+	}
+
+	@Override
+	public ProductDetailsResponseDto getProductDetails(Long productCode) {
+
+		ProductDetails productDetails = productDetailsRepository.findById(productCode)
+			.orElseThrow(() -> new IllegalArgumentException("해당 상품정보가 존재하지 않습니다."));
+
+		return ProductDetailsResponseDto.builder()
+			.productCode(productDetails.getProductCode())
+			.price(productDetails.getProductPrice())
+			.build();
+	}
+
+	@Override
+	public ProductFlagsResponseDto getProductFlags(Long productCode) {
+		// Q2. 여기는 상품에 대해 찜하기여부, 최신상품여부, 베스트 여부
+		// 단순 Boolean 처리이니, 위 3가지 필드에 대해 짬하기 나 베스트 등의 구현에 대해 신경쓰지 말고 새로 엔티티 생성할지?
+		return null;
+	}
+
+	@Override
+	public DiscountResponseDto getDiscountInfo(Long productCode) {
+		ProductDefaultDisCount productDefaultDisCount = discountRepository.findById(productCode)
+			.orElseThrow(() -> new IllegalArgumentException("해당 할인타입이 존재하지 않습니다."));
+		return DiscountResponseDto.builder()
+			.discountType(productDefaultDisCount.getDiscountType()) // Q3. enum 타입인데 알아서 DB에서 가져와 입력되는지?
+			.value(productDefaultDisCount.getValue())
 			.build();
 	}
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
@@ -107,6 +107,7 @@ public class ProductServiceImpl implements ProductService {
 	public ProductFlagsResponseDto getProductFlags(Long productCode) {
 		// Q2. 여기는 상품에 대해 찜하기여부, 최신상품여부, 베스트 여부
 		// 단순 Boolean 처리이니, 위 3가지 필드에 대해 짬하기 나 베스트 등의 구현에 대해 신경쓰지 말고 새로 엔티티 생성할지?
+
 		return null;
 	}
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
@@ -17,8 +17,10 @@ import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseD
 import starbucks3355.starbucksServer.domainProduct.entity.Product;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDefaultDisCount;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDetails;
+import starbucks3355.starbucksServer.domainProduct.entity.ProductFlags;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductImage;
 import starbucks3355.starbucksServer.domainProduct.repository.DiscountRepository;
+import starbucks3355.starbucksServer.domainProduct.repository.FlagsRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ImageRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductDetailsRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductRepository;
@@ -34,6 +36,7 @@ public class ProductServiceImpl implements ProductService {
 	private final ReviewRepository reviewRepository;
 	private final DiscountRepository discountRepository;
 	private final ProductDetailsRepository productDetailsRepository;
+	private final FlagsRepository flagsRepository;
 
 	@Override
 	public void addProduct(ProductRequestDto productRequestDto) {
@@ -60,10 +63,6 @@ public class ProductServiceImpl implements ProductService {
 	@Override
 	public ProductResponseDto getProduct(String productUuid) {
 
-		// Q0. 아래의 Mock uuid에 대해 컨트롤러에서 여러 서비스에 대해 uuid, id값을 줘야되니 컨트롤러에서 생성하는게 맞는건지?
-		String memberUuid;
-		memberUuid = UUID.randomUUID().toString(); // Member entity 목데이터
-
 		Product product = productRepository.findByProductUuid(productUuid)
 			.orElseThrow(() -> new IllegalArgumentException("해당 상품이 존재하지 않습니다."));
 
@@ -84,7 +83,8 @@ public class ProductServiceImpl implements ProductService {
 	// Q1.5 아래와 같이 쪼개어 생성된 getXXX 메서드들 만큼 Controller에는 @GetMapping으로 따로 처리하면 되는지?
 	@Override
 	public ProductImgResponseDto getImage(Long productCode) {
-		ProductImage productImage = imgRepository.findById(productCode)
+
+		ProductImage productImage = imgRepository.findByProductCode(productCode)
 			.orElseThrow(() -> new IllegalArgumentException("해당 이미지가 존재하지 않습니다."));
 		return ProductImgResponseDto.builder()
 			.productImgUrl(productImage.getS3Url())
@@ -92,13 +92,13 @@ public class ProductServiceImpl implements ProductService {
 	}
 
 	@Override
-	public ProductDetailsResponseDto getProductDetails(Long productCode) {
+	public ProductDetailsResponseDto getProductDetails(String productUuid) {
 
-		ProductDetails productDetails = productDetailsRepository.findById(productCode)
+		ProductDetails productDetails = productDetailsRepository.findByProductUuid(productUuid)
 			.orElseThrow(() -> new IllegalArgumentException("해당 상품정보가 존재하지 않습니다."));
 
 		return ProductDetailsResponseDto.builder()
-			.productCode(productDetails.getProductCode())
+			.productUuid(productDetails.getProductUuid())
 			.price(productDetails.getProductPrice())
 			.build();
 	}
@@ -107,8 +107,14 @@ public class ProductServiceImpl implements ProductService {
 	public ProductFlagsResponseDto getProductFlags(Long productCode) {
 		// Q2. 여기는 상품에 대해 찜하기여부, 최신상품여부, 베스트 여부
 		// 단순 Boolean 처리이니, 위 3가지 필드에 대해 짬하기 나 베스트 등의 구현에 대해 신경쓰지 말고 새로 엔티티 생성할지?
+		ProductFlags productFlags = flagsRepository.findByProductCode(productCode)
+			.orElseThrow(() -> new IllegalArgumentException("해당 상품정보가 존재하지 않습니다."));
 
-		return null;
+		return ProductFlagsResponseDto.builder()
+			.isLiked(productFlags.isLiked())
+			.isNew(productFlags.isNew())
+			.isBest(productFlags.isBest())
+			.build();
 	}
 
 	@Override

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/DiscountResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/DiscountResponseVo.java
@@ -4,15 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import starbucks3355.starbucksServer.domainProduct.entity.DiscountType;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProductResponseVo {
-	private String productUuid;
-	private String productName;
-	private String productDescription;
-	private String productInfo;
-
+public class DiscountResponseVo {
+	private DiscountType discountType;
+	private Integer value;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductDetailsResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductDetailsResponseVo.java
@@ -9,10 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProductResponseVo {
-	private String productUuid;
-	private String productName;
-	private String productDescription;
-	private String productInfo;
-
+public class ProductDetailsResponseVo {
+	private Long productCode; // 상품 옵션의 id 필드의 값을 뜻함
+	private Integer price;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductDetailsResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductDetailsResponseVo.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ProductDetailsResponseVo {
-	private Long productCode; // 상품 옵션의 id 필드의 값을 뜻함
+	private String productUuid; // 상품 옵션의 id 필드의 값을 뜻함
 	private Integer price;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductFlagsResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductFlagsResponseVo.java
@@ -9,10 +9,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProductResponseVo {
-	private String productUuid;
-	private String productName;
-	private String productDescription;
-	private String productInfo;
-
+public class ProductFlagsResponseVo {
+	private Boolean isLiked;
+	private Boolean isNew;
+	private Boolean isBest;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductImgResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductImgResponseVo.java
@@ -9,10 +9,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProductResponseVo {
-	private String productUuid;
-	private String productName;
-	private String productDescription;
-	private String productInfo;
-
+public class ProductImgResponseVo {
+	private String productImgUrl;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ReviewResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ReviewResponseVo.java
@@ -9,10 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProductResponseVo {
-	private String productUuid;
-	private String productName;
-	private String productDescription;
-	private String productInfo;
-
+public class ReviewResponseVo {
+	private Double reviewScore;
+	private Integer reviewCount;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #26 
-> 추가 작업 필요
1. 상품 이미지 조회시 단순히 대표 이미지 엔티티를 하나 불러올지 or 이미지리스트 테이블에 대표이미지 구분 컬럼을 넣어서 추가적인 로직을 거쳐 조회할지
2. 상품의 각종 여부(찜하기 여부, 신상, 베스트 여부)는 단순히 boolean 값으로만 넘기면 되는것일지?
-> 이미지리스트를 불러오고 그 중 대표이미지라는 컬럼값이 true 인 경우를 뽑아내는식으로 가야 하는지?
3. 상품 상세 정보 (옵션)과 상품 할인 정보는 서로 연관관계가 있는데, 이 두 테이블은 서로 주요 도메인 테이블이 아니기에 uuid 말고 id로 사용해도 괜찮을지? 
4.  리뷰에 대해서는 따로 Service 계층을 생성할지?, 상품 Service에서 로직을 처리할지?


## 📝작업 내용

> 기존의 하나의 api로 취급하던 상품 조회 api에 대해서
상품 메인 정보 조회 api + 상품 상세 정보(옵션) 조회 api + 상품 이미지 조회 api + 상품 할인 정보 조회 api + 

### 스크린샷 (선택)
<img width="1463" alt="스크린샷 2024-09-04 오전 11 55 24" src="https://github.com/user-attachments/assets/f5a1ee0f-3331-41a1-bce4-1e00335e3ad5">

## 💬리뷰 요구사항(선택)
