### PR TITLE
Feature/#58

### DIFF
--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
@@ -112,7 +112,7 @@ public class ProductController {
 	}
 
 	@GetMapping("/search/{searchInfo}")
-	@Operation(summary = "상품 검색을 통힌 정보 조회")
+	@Operation(summary = "상품 검색(상품명, 태그)을 통힌 정보 조회")
 	public CommonResponseEntity<List<ProductInfoResponseVo>> getProductSearchInfo(
 		@PathVariable String searchInfo
 	) {

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
@@ -21,9 +21,13 @@ import starbucks3355.starbucksServer.common.entity.CommonResponseSliceEntity;
 import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountPriceResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountRateResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductInfoResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 import starbucks3355.starbucksServer.domainProduct.service.ProductService;
+import starbucks3355.starbucksServer.domainProduct.vo.response.DiscountPriceResponseVo;
+import starbucks3355.starbucksServer.domainProduct.vo.response.DiscountRateResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductDetailsPriceResponseVo;
+import starbucks3355.starbucksServer.domainProduct.vo.response.ProductInfoResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductResponseVo;
 
 @Slf4j
@@ -83,27 +87,45 @@ public class ProductController {
 
 	@GetMapping("/productDiscountRateInfo/{productUuid}")
 	@Operation(summary = "상품 할인률 정보 조회")
-	public CommonResponseEntity<DiscountRateResponseDto> getProductRateDiscountInfo(
+	public CommonResponseEntity<DiscountRateResponseVo> getProductRateDiscountInfo(
 		@PathVariable String productUuid) {
 		DiscountRateResponseDto discountRateResponseDto = productService.getDiscountRateInfo(productUuid);
 
 		return new CommonResponseEntity<>(
 			HttpStatus.OK,
 			CommonResponseMessage.SUCCESS.getMessage(),
-			discountRateResponseDto
+			discountRateResponseDto.dtoToResponseVo()
 		);
 	}
 
 	@GetMapping("/productDiscountPriceInfo/{productUuid}")
 	@Operation(summary = "상품 할인금액 정보 조회")
-	public CommonResponseEntity<DiscountPriceResponseDto> getProductPriceDiscountInfo(
+	public CommonResponseEntity<DiscountPriceResponseVo> getProductPriceDiscountInfo(
 		@PathVariable String productUuid) {
 		DiscountPriceResponseDto discountPriceResponseDto = productService.getDiscountPriceInfo(productUuid);
 
 		return new CommonResponseEntity<>(
 			HttpStatus.OK,
 			CommonResponseMessage.SUCCESS.getMessage(),
-			discountPriceResponseDto
+			discountPriceResponseDto.dtoToResponseVo()
+		);
+	}
+
+	@GetMapping("/search/{searchInfo}")
+	@Operation(summary = "상품 검색을 통힌 정보 조회")
+	public CommonResponseEntity<List<ProductInfoResponseVo>> getProductSearchInfo(
+		@PathVariable String searchInfo
+	) {
+		List<ProductInfoResponseDto> productsInfoDtoList = productService.getProductsInfo(searchInfo);
+
+		List<ProductInfoResponseVo> productsInfoVoList = productsInfoDtoList.stream()
+			.map(ProductInfoResponseDto::dtoToResponseVo)
+			.collect(Collectors.toList());
+
+		return new CommonResponseEntity<>(
+			HttpStatus.OK,
+			CommonResponseMessage.SUCCESS.getMessage(),
+			productsInfoVoList
 		);
 	}
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/DiscountPriceResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/DiscountPriceResponseDto.java
@@ -3,10 +3,18 @@ package starbucks3355.starbucksServer.domainProduct.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import starbucks3355.starbucksServer.domainProduct.entity.DiscountType;
+import starbucks3355.starbucksServer.domainProduct.vo.response.DiscountPriceResponseVo;
 
 @Getter
 @Builder
 public class DiscountPriceResponseDto {
 	private DiscountType discountType;
 	private Integer discountPrice;
+
+	public DiscountPriceResponseVo dtoToResponseVo() {
+		return DiscountPriceResponseVo.builder()
+			.discountType(discountType)
+			.discountPrice(discountPrice)
+			.build();
+	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/DiscountRateResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/DiscountRateResponseDto.java
@@ -3,10 +3,18 @@ package starbucks3355.starbucksServer.domainProduct.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import starbucks3355.starbucksServer.domainProduct.entity.DiscountType;
+import starbucks3355.starbucksServer.domainProduct.vo.response.DiscountRateResponseVo;
 
 @Getter
 @Builder
 public class DiscountRateResponseDto {
 	private DiscountType discountType;
 	private Integer discountRate;
+
+	public DiscountRateResponseVo dtoToResponseVo() {
+		return DiscountRateResponseVo.builder()
+			.discountType(discountType)
+			.discountRate(discountRate)
+			.build();
+	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductInfoResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductInfoResponseDto.java
@@ -1,0 +1,18 @@
+package starbucks3355.starbucksServer.domainProduct.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import starbucks3355.starbucksServer.domainProduct.vo.response.ProductInfoResponseVo;
+
+@Getter
+@Builder
+public class ProductInfoResponseDto {
+	// 검색을 통해 상품의 uuid를 받기 위한 dto
+	private String productUuid;
+
+	public ProductInfoResponseVo dtoToResponseVo() {
+		return ProductInfoResponseVo.builder()
+			.productUuid(this.productUuid)
+			.build();
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductTag.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductTag.java
@@ -17,7 +17,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class ProductTag { //out -> etc등의 도메인으로
+public class ProductTag { //out -> etc등의 도메인으로 -> 스타벅스 온라인 스토어를 살펴보니 상품에만 태그가 존재하는것으로 확인됨
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductTag.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductTag.java
@@ -23,5 +23,5 @@ public class ProductTag { //out -> etc등의 도메인으로
 	private Long id;
 	@Column(length = 255)
 	private String tagName;
-	private Long productCode;
+	private String productUuid;
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductRepository.java
@@ -1,5 +1,6 @@
 package starbucks3355.starbucksServer.domainProduct.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
@@ -14,5 +15,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	Optional<Product> findByProductUuid(String ProductUuid);
 
 	Slice<Product> findPageByProductUuid(String ProductUuid, Pageable pageable);
+
+	List<Product> findByProductNameContaining(String searchName);
 
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductTagRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductTagRepository.java
@@ -1,0 +1,13 @@
+package starbucks3355.starbucksServer.domainProduct.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import starbucks3355.starbucksServer.domainProduct.entity.ProductTag;
+
+@Repository
+public interface ProductTagRepository extends JpaRepository<ProductTag, Long> {
+	List<ProductTag> findByTagNameContaining(String searchTag);
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
@@ -1,5 +1,7 @@
 package starbucks3355.starbucksServer.domainProduct.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Slice;
 
 import starbucks3355.starbucksServer.domainProduct.dto.request.ProductRequestDto;
@@ -7,6 +9,7 @@ import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountPriceRes
 import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountRateResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductFlagsResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductInfoResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 
 public interface ProductService {
@@ -17,6 +20,8 @@ public interface ProductService {
 	public Slice<ProductResponseDto> getProducts(int page, int size);
 
 	public ProductResponseDto getProduct(String productUuid);
+
+	public List<ProductInfoResponseDto> getProductsInfo(String productSearchInfo);
 
 	public ProductDetailsPriceResponseDto getProductPrice(String productUuid);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
@@ -1,5 +1,6 @@
 package starbucks3355.starbucksServer.domainProduct.service;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.PageRequest;
@@ -14,15 +15,18 @@ import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountPriceRes
 import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountRateResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductFlagsResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductInfoResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 import starbucks3355.starbucksServer.domainProduct.entity.Product;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDefaultDisCount;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDetails;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductFlags;
+import starbucks3355.starbucksServer.domainProduct.entity.ProductTag;
 import starbucks3355.starbucksServer.domainProduct.repository.DiscountRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.FlagsRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductDetailsRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductRepository;
+import starbucks3355.starbucksServer.domainProduct.repository.ProductTagRepository;
 
 @Service
 @Slf4j
@@ -33,6 +37,7 @@ public class ProductServiceImpl implements ProductService {
 	private final DiscountRepository discountRepository;
 	private final ProductDetailsRepository productDetailsRepository;
 	private final FlagsRepository flagsRepository;
+	private final ProductTagRepository productTagRepository;
 
 	@Override
 	public void addProduct(ProductRequestDto productRequestDto) {
@@ -68,6 +73,28 @@ public class ProductServiceImpl implements ProductService {
 			.productDescription(product.getProductDescription())
 			.productInfo(product.getProductInfo())
 			.build();
+	}
+
+	@Override
+	public List<ProductInfoResponseDto> getProductsInfo(String productSearchInfo) {
+		// 검색어 첫글자가 # 이면 findByTagNameContaining, 이외에는 findByProductNameContaining
+		// 상품의 이름이나 태그를 통해서 상품의 uuid 값 반환
+		if (productSearchInfo.startsWith("#")) {
+			List<ProductTag> tagUuidList = productTagRepository.findByTagNameContaining(productSearchInfo);
+			return tagUuidList.stream()
+				.map(tagOfProductUuid -> ProductInfoResponseDto.builder()
+					.productUuid(tagOfProductUuid.getProductUuid())
+					.build()
+				).toList();
+
+		} else {
+			List<Product> nameUuidList = productRepository.findByProductNameContaining(productSearchInfo);
+			return nameUuidList.stream()
+				.map(nameOfProductUuid -> ProductInfoResponseDto.builder()
+					.productUuid(nameOfProductUuid.getProductUuid())
+					.build()
+				).toList();
+		}
 	}
 
 	@Override

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductInfoResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductInfoResponseVo.java
@@ -1,0 +1,16 @@
+package starbucks3355.starbucksServer.domainProduct.vo.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductInfoResponseVo {
+	// 검색을 통해 상품의 uuid를 받기 위한 vo
+	String productUuid;
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #58 

## 📝작업 내용

> 상품의 이름과 태그에 대해 검색 기능 추가


### 스크린샷 (선택) 
1. 상품명으로 검색 (상품명의 일부분으로도 검색 가능)
<img width="619" alt="스크린샷 2024-09-12 오후 2 29 49" src="https://github.com/user-attachments/assets/90aca051-ea19-48c0-b957-7a435beeb51c">




2. 상품태그로 검색(검색어의 제일 앞에 '#' 이 붙는 것)
<img width="619" alt="스크린샷 2024-09-12 오후 2 29 07" src="https://github.com/user-attachments/assets/1f6c4dd1-957f-44b8-a76d-53cba97efde9">

