### PR TITLE
feat: 리뷰/이미지/장바구니에 대해 memberUuid 더미데이터를 넣어 처리했던 코드들에 대해 액세스토큰을 통해 처리

### DIFF
--- a/src/main/java/starbucks3355/starbucksServer/common/config/SecurityConfig.java
+++ b/src/main/java/starbucks3355/starbucksServer/common/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
 						"/api/v1/category/**",
 						// "/api/v1/member/**",
 						"/api/v1/wishList/**",
+						"/api/v1/review/**",
 						"/api/v1/vendor/**",
 						"/swagger-ui/**",
 						"/v3/api-docs/**",

--- a/src/main/java/starbucks3355/starbucksServer/domainImage/controller/ImageController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainImage/controller/ImageController.java
@@ -3,6 +3,7 @@ package starbucks3355.starbucksServer.domainImage.controller;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import starbucks3355.starbucksServer.auth.entity.AuthUserDetail;
 import starbucks3355.starbucksServer.common.entity.CommonResponseEntity;
 import starbucks3355.starbucksServer.common.entity.CommonResponseMessage;
 import starbucks3355.starbucksServer.domainImage.dto.out.ImageResponseDto;
@@ -63,7 +65,8 @@ public class ImageController {
 	@PostMapping("/addMedia/{otherUuid}")
 	@Operation(summary = "개체(상품, 리뷰, 쿠폰)에 대한 이미지 추가")
 	public CommonResponseEntity<Void> addImages(
-		@RequestBody List<ImageRequestVo> imageRequestVoList
+		@RequestBody List<ImageRequestVo> imageRequestVoList,
+		@AuthenticationPrincipal AuthUserDetail authUserDetail
 	) {
 		imageService.addImages(imageRequestVoList.stream()
 			.map(ImageRequestVo::voToDto)
@@ -80,7 +83,8 @@ public class ImageController {
 	@DeleteMapping("/deleteMedia/{id}/{otherUuid}")
 	@Operation(summary = "개체(상품, 리뷰, 쿠폰)에 대한 이미지 삭제")
 	public CommonResponseEntity<Void> deleteImage(
-		@PathVariable Long id, String otherUuid
+		@PathVariable Long id, String otherUuid,
+		@AuthenticationPrincipal AuthUserDetail authUserDetail
 	) {
 		imageService.deleteImage(id, otherUuid);
 
@@ -95,7 +99,8 @@ public class ImageController {
 	// 개체(상품, 리뷰, 쿠폰)에 대한 모든 이미지 삭제(수정의 경우 기존 등록된 모든 이미지리스트를 삭제하고 새 리스트을 입력할 것)
 	@Operation(summary = "개체(상품, 리뷰, 쿠폰)에 대한 모든 이미지 삭제")
 	public CommonResponseEntity<Void> deleteAllImage(
-		@PathVariable String otherUuid
+		@PathVariable String otherUuid,
+		@AuthenticationPrincipal AuthUserDetail authUserDetail햣
 	) {
 		imageService.deleteAllImages(otherUuid);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewModifyRequestDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewModifyRequestDto.java
@@ -1,0 +1,14 @@
+package starbucks3355.starbucksServer.domainReview.dto.in;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewModifyRequestDto {
+	private String content;
+	private Integer reviewScore;
+	private LocalDateTime regDate, modDate;
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Slice;
 
+import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.MyReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
@@ -20,7 +21,7 @@ public interface ReviewService {
 
 	void addReview(ReviewRequestDto reviewRequestDto);
 
-	void modifyReview(ReviewRequestDto reviewRequestDto, String reviewUuid);
+	void modifyReview(ReviewModifyRequestDto reviewModifyRequestDto, String reviewUuid);
 
 	void deleteReview(Long reviewId); // 베스트 등을 위해 soft delete로 갈지? -> 엔티티 부터 모든 관련된 곳에 필드 추가 요구됨
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewServiceImpl.java
@@ -2,7 +2,6 @@ package starbucks3355.starbucksServer.domainReview.service;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import starbucks3355.starbucksServer.domainImage.repository.ImageRepository;
 import starbucks3355.starbucksServer.domainMember.repository.MemberRepository;
+import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.MyReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
@@ -108,23 +108,25 @@ public class ReviewServiceImpl implements ReviewService {
 
 	@Override
 	public void addReview(ReviewRequestDto reviewRequestDto) {
-		String reviewUuid = UUID.randomUUID().toString();
-		String productUuid = UUID.randomUUID().toString();
-		String memberUuid = UUID.randomUUID().toString();
+		// String reviewUuid = UUID.randomUUID().toString();
+		// String productUuid = UUID.randomUUID().toString();
+		// String memberUuid = UUID.randomUUID().toString();
 		// 스웨거랑 별개로 리뷰 등록 시에는 리뷰, 상품, 회원의 UUID를 생성하여 저장
-		reviewRepository.save(reviewRequestDto.toEntity(reviewUuid, productUuid, memberUuid));
+
+		reviewRepository.save(reviewRequestDto.toEntity(reviewRequestDto.getReviewUuid(),
+			reviewRequestDto.getProductUuid(), reviewRequestDto.getMemberUuid()));
 	}
 
 	@Override
 	@Transactional
-	public void modifyReview(ReviewRequestDto reviewRequestDto, String reviewUuid) {
+	public void modifyReview(ReviewModifyRequestDto reviewModifyRequestDto, String reviewUuid) {
 		// String reviewUuid = UUID.randomUUID().toString();
 		Optional<Review> result = reviewRepository.findByReviewUuid(reviewUuid);
 
 		Review review = result.get();
 
-		review.modifyContent(reviewRequestDto.getContent());
-		review.modifyReviewScore(reviewRequestDto.getReviewScore());
+		review.modifyContent(reviewModifyRequestDto.getContent());
+		review.modifyReviewScore(reviewModifyRequestDto.getReviewScore());
 
 		reviewRepository.save(review);
 
@@ -132,7 +134,9 @@ public class ReviewServiceImpl implements ReviewService {
 
 	@Override
 	@Transactional
-	public void deleteReview(Long reviewId) {
+	public void deleteReview(
+		Long reviewId
+	) {
 		reviewRepository.deleteById(reviewId);
 	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/vo/in/ReviewModifyRequestVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/vo/in/ReviewModifyRequestVo.java
@@ -7,11 +7,8 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class ReviewRequestVo {
+public class ReviewModifyRequestVo {
 	private String content;
-	private String reviewUuid;
 	private Integer reviewScore;
-	private String productUuid; // 회원이 구매한 '상품'에 대한 리뷰
-	// private String memberUuid; // 미확실 필드: 시큐리티의 토큰처리에 따라 사용여부 결정
 	private LocalDateTime regDate, modDate;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #76 

## 📝작업 내용

> 요약: 본인 파트에 대해서 로그인한 유저가 사용할 api 에 대해 액세스토큰관련 적용


> 기존에는 각종 도메인에 대하여 로그인한 유저가 사용할 수 있는 api에 대해 memberUuid 더미데이터 삽입하는 형식으로 처리
> 시큐리티 적용과 로그인 기능 개발을 통해 더미데이터 삽입이 아닌 액세스토큰을 발급받아와서 처리하는 형식으로 변경
> 이에 따라 dto/vo에서도 memberUuid를 적용받는 것은 삭제처리함



