### PR TITLE
Feature/#102

### DIFF
--- a/src/main/java/starbucks3355/starbucksServer/domainCart/controller/CartController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/controller/CartController.java
@@ -1,4 +1,4 @@
-package starbucks3355.starbucksServer.domainWishList.controller;
+package starbucks3355.starbucksServer.domainCart.controller;
 
 import java.util.List;
 
@@ -20,36 +20,36 @@ import lombok.extern.slf4j.Slf4j;
 import starbucks3355.starbucksServer.auth.entity.AuthUserDetail;
 import starbucks3355.starbucksServer.common.entity.CommonResponseEntity;
 import starbucks3355.starbucksServer.common.entity.CommonResponseMessage;
-import starbucks3355.starbucksServer.domainWishList.dto.in.WishListRequestDto;
-import starbucks3355.starbucksServer.domainWishList.dto.out.TotalInfoResponseDto;
-import starbucks3355.starbucksServer.domainWishList.dto.out.WishListResponseDto;
-import starbucks3355.starbucksServer.domainWishList.service.WishListService;
-import starbucks3355.starbucksServer.domainWishList.vo.in.WishListRequestVo;
-import starbucks3355.starbucksServer.domainWishList.vo.out.TotalInfoResponseVo;
-import starbucks3355.starbucksServer.domainWishList.vo.out.WishListResponseVo;
+import starbucks3355.starbucksServer.domainCart.dto.in.CartRequestDto;
+import starbucks3355.starbucksServer.domainCart.dto.out.CartResponseDto;
+import starbucks3355.starbucksServer.domainCart.dto.out.TotalInfoResponseDto;
+import starbucks3355.starbucksServer.domainCart.service.CartService;
+import starbucks3355.starbucksServer.domainCart.vo.in.CartRequestVo;
+import starbucks3355.starbucksServer.domainCart.vo.out.CartResponseVo;
+import starbucks3355.starbucksServer.domainCart.vo.out.TotalInfoResponseVo;
 
 @Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/wishList")
 @Tag(name = "WishList", description = "장바구니 API")
-public class WishListController {
-	private final WishListService wishListService;
+public class CartController {
+	private final CartService wishListService;
 
 	@GetMapping("/view")
 	@Operation(summary = " 나의 상품 장바구니 조회")
-	public CommonResponseEntity<List<WishListResponseVo>> getMyWishList(
+	public CommonResponseEntity<List<CartResponseVo>> getMyWishList(
 		@AuthenticationPrincipal AuthUserDetail authUserDetail
 	) {
 		String memberUuid = authUserDetail.getUuid(); // 로그인된 사용자의 UUID 가져오기
 
-		List<WishListResponseDto> wishListRequestDtoList = wishListService.getMyWishListItems(memberUuid);
+		List<CartResponseDto> wishListRequestDtoList = wishListService.getMyWishListItems(memberUuid);
 
 		return new CommonResponseEntity<>(
 			HttpStatus.OK,
 			CommonResponseMessage.SUCCESS.getMessage(),
 			wishListRequestDtoList.stream()
-				.map(WishListResponseDto::dtoToResponseVo)
+				.map(CartResponseDto::dtoToResponseVo)
 				.toList());
 
 	}
@@ -110,12 +110,12 @@ public class WishListController {
 	@Operation(summary = "상품 상세페이지에서 장바구니에 n개 추가")
 	public CommonResponseEntity<Void> addProductToWishListFromProductDetailsPage(
 		@AuthenticationPrincipal AuthUserDetail authUserDetail,
-		@RequestBody WishListRequestVo wishListRequestVo,
+		@RequestBody CartRequestVo wishListRequestVo,
 		@PathVariable int quantity) {
 
 		String memberUuid = authUserDetail.getUuid();
 
-		WishListRequestDto wishListRequestDto = WishListRequestDto.builder()
+		CartRequestDto wishListRequestDto = CartRequestDto.builder()
 			.productUuid(wishListRequestVo.getProductUuid())
 			.memberUuid(memberUuid)
 			.isChecked(true)

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/dto/in/CartRequestDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/dto/in/CartRequestDto.java
@@ -1,14 +1,14 @@
-package starbucks3355.starbucksServer.domainWishList.dto.out;
+package starbucks3355.starbucksServer.domainCart.dto.in;
 
 import java.time.LocalDateTime;
 
 import lombok.Builder;
 import lombok.Getter;
-import starbucks3355.starbucksServer.domainWishList.vo.out.WishListResponseVo;
+import starbucks3355.starbucksServer.domainCart.entity.WishList;
 
 @Getter
 @Builder
-public class WishListResponseDto {
+public class CartRequestDto {
 	private String productUuid;
 	private String memberUuid;
 	private boolean isChecked;
@@ -16,15 +16,17 @@ public class WishListResponseDto {
 	private Integer currentQuantity;
 	private LocalDateTime regDate, modDate;
 
-	public WishListResponseVo dtoToResponseVo() {
-		return WishListResponseVo.builder()
+	public WishList toEntity(String productUuid, String memberUuid) {
+		return WishList.builder()
 			.productUuid(productUuid)
 			.memberUuid(memberUuid)
 			.isChecked(isChecked)
 			.limitQuantity(limitQuantity)
 			.currentQuantity(currentQuantity)
-			.regDate(regDate)
-			.modDate(modDate)
 			.build();
+	}
+
+	public void updateCurrentQuantity(int quantity) {
+		this.currentQuantity = quantity;
 	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/dto/in/CartRequestDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/dto/in/CartRequestDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 import lombok.Builder;
 import lombok.Getter;
-import starbucks3355.starbucksServer.domainCart.entity.WishList;
+import starbucks3355.starbucksServer.domainCart.entity.Cart;
 
 @Getter
 @Builder
@@ -16,8 +16,8 @@ public class CartRequestDto {
 	private Integer currentQuantity;
 	private LocalDateTime regDate, modDate;
 
-	public WishList toEntity(String productUuid, String memberUuid) {
-		return WishList.builder()
+	public Cart toEntity(String productUuid, String memberUuid) {
+		return Cart.builder()
 			.productUuid(productUuid)
 			.memberUuid(memberUuid)
 			.isChecked(isChecked)

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/dto/out/CartResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/dto/out/CartResponseDto.java
@@ -1,14 +1,14 @@
-package starbucks3355.starbucksServer.domainWishList.dto.in;
+package starbucks3355.starbucksServer.domainCart.dto.out;
 
 import java.time.LocalDateTime;
 
 import lombok.Builder;
 import lombok.Getter;
-import starbucks3355.starbucksServer.domainWishList.entity.WishList;
+import starbucks3355.starbucksServer.domainCart.vo.out.CartResponseVo;
 
 @Getter
 @Builder
-public class WishListRequestDto {
+public class CartResponseDto {
 	private String productUuid;
 	private String memberUuid;
 	private boolean isChecked;
@@ -16,17 +16,15 @@ public class WishListRequestDto {
 	private Integer currentQuantity;
 	private LocalDateTime regDate, modDate;
 
-	public WishList toEntity(String productUuid, String memberUuid) {
-		return WishList.builder()
+	public CartResponseVo dtoToResponseVo() {
+		return CartResponseVo.builder()
 			.productUuid(productUuid)
 			.memberUuid(memberUuid)
 			.isChecked(isChecked)
 			.limitQuantity(limitQuantity)
 			.currentQuantity(currentQuantity)
+			.regDate(regDate)
+			.modDate(modDate)
 			.build();
-	}
-
-	public void updateCurrentQuantity(int quantity) {
-		this.currentQuantity = quantity;
 	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/dto/out/TotalInfoResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/dto/out/TotalInfoResponseDto.java
@@ -1,8 +1,8 @@
-package starbucks3355.starbucksServer.domainWishList.dto.out;
+package starbucks3355.starbucksServer.domainCart.dto.out;
 
 import lombok.Builder;
 import lombok.Getter;
-import starbucks3355.starbucksServer.domainWishList.vo.out.TotalInfoResponseVo;
+import starbucks3355.starbucksServer.domainCart.vo.out.TotalInfoResponseVo;
 
 @Getter
 @Builder

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/entity/Cart.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/entity/Cart.java
@@ -15,7 +15,7 @@ import starbucks3355.starbucksServer.common.entity.BaseEntity;
 @Getter
 @NoArgsConstructor
 @ToString
-public class WishList extends BaseEntity {
+public class Cart extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -28,7 +28,7 @@ public class WishList extends BaseEntity {
 	private Integer currentQuantity;
 
 	@Builder
-	public WishList(int limitQuantity, String memberUuid, boolean isChecked, String productUuid,
+	public Cart(int limitQuantity, String memberUuid, boolean isChecked, String productUuid,
 		Integer currentQuantity) {
 		this.limitQuantity = limitQuantity;
 		this.memberUuid = memberUuid;

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/entity/WishList.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/entity/WishList.java
@@ -1,4 +1,4 @@
-package starbucks3355.starbucksServer.domainWishList.entity;
+package starbucks3355.starbucksServer.domainCart.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/repository/CartRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/repository/CartRepository.java
@@ -7,13 +7,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 
-import starbucks3355.starbucksServer.domainCart.entity.WishList;
+import starbucks3355.starbucksServer.domainCart.entity.Cart;
 
 @Repository
-public interface CartRepository extends JpaRepository<WishList, Long> {
-	List<WishList> findByMemberUuid(String memberUuid);
+public interface CartRepository extends JpaRepository<Cart, Long> {
+	List<Cart> findByMemberUuid(String memberUuid);
 
-	Optional<WishList> findByMemberUuidAndProductUuid(String memberUuid, String productUuid);
+	Optional<Cart> findByMemberUuidAndProductUuid(String memberUuid, String productUuid);
 
 	@Modifying
 	void deleteByMemberUuidAndProductUuid(String memberUuid, String productUuid);

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/repository/CartRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/repository/CartRepository.java
@@ -1,4 +1,4 @@
-package starbucks3355.starbucksServer.domainWishList.repository;
+package starbucks3355.starbucksServer.domainCart.repository;
 
 import java.util.List;
 import java.util.Optional;
@@ -7,10 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 
-import starbucks3355.starbucksServer.domainWishList.entity.WishList;
+import starbucks3355.starbucksServer.domainCart.entity.WishList;
 
 @Repository
-public interface WishListRepository extends JpaRepository<WishList, Long> {
+public interface CartRepository extends JpaRepository<WishList, Long> {
 	List<WishList> findByMemberUuid(String memberUuid);
 
 	Optional<WishList> findByMemberUuidAndProductUuid(String memberUuid, String productUuid);

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/service/CartService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/service/CartService.java
@@ -1,15 +1,15 @@
-package starbucks3355.starbucksServer.domainWishList.service;
+package starbucks3355.starbucksServer.domainCart.service;
 
 import java.util.List;
 
-import starbucks3355.starbucksServer.domainWishList.dto.in.WishListRequestDto;
-import starbucks3355.starbucksServer.domainWishList.dto.out.TotalInfoResponseDto;
-import starbucks3355.starbucksServer.domainWishList.dto.out.WishListResponseDto;
+import starbucks3355.starbucksServer.domainCart.dto.in.CartRequestDto;
+import starbucks3355.starbucksServer.domainCart.dto.out.CartResponseDto;
+import starbucks3355.starbucksServer.domainCart.dto.out.TotalInfoResponseDto;
 
-public interface WishListService {
-	List<WishListResponseDto> getMyWishListItems(String memberUuid);
+public interface CartService {
+	List<CartResponseDto> getMyWishListItems(String memberUuid);
 
-	void addWishList(WishListRequestDto wishListRequestDto);
+	void addWishList(CartRequestDto wishListRequestDto);
 
 	void deleteWishList(String memberUuid, String productUuid);
 
@@ -34,7 +34,7 @@ public interface WishListService {
 	// void addWishListIsExistProductInWishList(WishListRequestDto wishListRequestDto);
 
 	// 상품 상세 페이지에서 선택한 어떤 상품 대해 그 상품 N개를 장바구니에 넣을때 상품이 존재하지 않으면 0+n이 limitQuantity 이하 까지 가능, 장바구니에 존재하면 currentQuantity를 n만큼 증가시킴 (limitQuantity 이하까지 증가 가능)
-	void addWishListAtProductPage(WishListRequestDto wishListRequestDto, int quantity);
+	void addWishListAtProductPage(CartRequestDto wishListRequestDto, int quantity);
 
 	// 장바구니에 담긴 상품들중 체크된 품목에 대한 것들을 통해 총 할인금액과 총 결제금액을 계산
 	TotalInfoResponseDto getWishListTotalPriceAndDiscount(String memberUuid);

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/service/CartServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/service/CartServiceImpl.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import starbucks3355.starbucksServer.domainCart.dto.in.CartRequestDto;
 import starbucks3355.starbucksServer.domainCart.dto.out.CartResponseDto;
 import starbucks3355.starbucksServer.domainCart.dto.out.TotalInfoResponseDto;
-import starbucks3355.starbucksServer.domainCart.entity.WishList;
+import starbucks3355.starbucksServer.domainCart.entity.Cart;
 import starbucks3355.starbucksServer.domainCart.repository.CartRepository;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDefaultDisCount;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDetails;
@@ -31,20 +31,20 @@ public class CartServiceImpl implements CartService {
 
 	@Override
 	public List<CartResponseDto> getMyWishListItems(String memberUuid) {
-		List<WishList> myWishList = wishListRepository.findByMemberUuid(memberUuid);
+		List<Cart> myCart = wishListRepository.findByMemberUuid(memberUuid);
 
-		if (myWishList != null) {
-			return myWishList.stream()
-				.sorted(Comparator.comparing(WishList::getModDate).reversed())
-				.map(myWishListItem -> CartResponseDto.builder()
-					.productUuid(myWishListItem.getProductUuid())
-					.memberUuid(myWishListItem.getMemberUuid())
+		if (myCart != null) {
+			return myCart.stream()
+				.sorted(Comparator.comparing(Cart::getModDate).reversed())
+				.map(myCartItem -> CartResponseDto.builder()
+					.productUuid(myCartItem.getProductUuid())
+					.memberUuid(myCartItem.getMemberUuid())
 					.isChecked(
-						myWishListItem.isChecked()) // Java의 Bean 규약에 따르면, boolean 타입 필드는 is 접두사를 사용하여 getter 메서드가 생성됨
-					.limitQuantity(myWishListItem.getLimitQuantity())
-					.currentQuantity(myWishListItem.getCurrentQuantity())
-					.regDate(myWishListItem.getRegDate())
-					.modDate(myWishListItem.getModDate())
+						myCartItem.isChecked()) // Java의 Bean 규약에 따르면, boolean 타입 필드는 is 접두사를 사용하여 getter 메서드가 생성됨
+					.limitQuantity(myCartItem.getLimitQuantity())
+					.currentQuantity(myCartItem.getCurrentQuantity())
+					.regDate(myCartItem.getRegDate())
+					.modDate(myCartItem.getModDate())
 					.build()).toList();
 		}
 
@@ -73,12 +73,12 @@ public class CartServiceImpl implements CartService {
 	@Override
 	@Transactional
 	public void deleteWishListChecked(String memberUuid) {
-		List<WishList> wishLists = wishListRepository.findByMemberUuid(memberUuid);
+		List<Cart> carts = wishListRepository.findByMemberUuid(memberUuid);
 
-		wishLists.stream()
-			.filter(WishList::isChecked)
+		carts.stream()
+			.filter(Cart::isChecked)
 			.forEach(
-				wishList -> wishListRepository.deleteByMemberUuidAndProductUuid(memberUuid, wishList.getProductUuid()));
+				cart -> wishListRepository.deleteByMemberUuidAndProductUuid(memberUuid, cart.getProductUuid()));
 
 	}
 
@@ -86,10 +86,10 @@ public class CartServiceImpl implements CartService {
 	@Transactional
 	public void modifyAddWishList(String memberUuid, String productUuid) {
 		wishListRepository.findByMemberUuidAndProductUuid(memberUuid, productUuid)
-			.ifPresent(wishList -> {
-				if (wishList.getCurrentQuantity() < wishList.getLimitQuantity()) {
-					wishList.updateCurrentQuantity(wishList.getCurrentQuantity() + 1);
-					wishListRepository.save(wishList);
+			.ifPresent(cart -> {
+				if (cart.getCurrentQuantity() < cart.getLimitQuantity()) {
+					cart.updateCurrentQuantity(cart.getCurrentQuantity() + 1);
+					wishListRepository.save(cart);
 				} else {
 					throw new RuntimeException("상품의 최대 수량을 초과할 수 없습니다.");
 				}
@@ -100,10 +100,10 @@ public class CartServiceImpl implements CartService {
 	@Transactional
 	public void modifySubtractWishList(String memberUuid, String productUuid) {
 		wishListRepository.findByMemberUuidAndProductUuid(memberUuid, productUuid)
-			.ifPresent(wishList -> {
-				if (wishList.getCurrentQuantity() > 1) {
-					wishList.updateCurrentQuantity(wishList.getCurrentQuantity() - 1);
-					wishListRepository.save(wishList);
+			.ifPresent(cart -> {
+				if (cart.getCurrentQuantity() > 1) {
+					cart.updateCurrentQuantity(cart.getCurrentQuantity() - 1);
+					wishListRepository.save(cart);
 				} else {
 					throw new RuntimeException("상품의 최소 수량은 1개입니다.");
 				}
@@ -113,27 +113,27 @@ public class CartServiceImpl implements CartService {
 	@Override
 	@Transactional
 	public void modifyWishListCheck(String memberUuid, String productUuid) {
-		Optional<WishList> result = wishListRepository.findByMemberUuidAndProductUuid(memberUuid, productUuid);
+		Optional<Cart> result = wishListRepository.findByMemberUuidAndProductUuid(memberUuid, productUuid);
 
-		WishList wishList = result.get();
+		Cart cart = result.get();
 
-		wishList.updateChecked(!wishList.isChecked());
+		cart.updateChecked(!cart.isChecked());
 
 	}
 
 	@Override
 	@Transactional
 	public void modifyWishListAllSelect(String memberUuid) {
-		List<WishList> wishLists = wishListRepository.findByMemberUuid(memberUuid);
+		List<Cart> carts = wishListRepository.findByMemberUuid(memberUuid);
 
 		// wishLists에 대해 isChecked의 값이 false 인게 하나라도 존재한다면 모든 wishList의 isChecked를 true로 변경
-		if (wishLists.stream().anyMatch(wishList -> wishList.isChecked() == false)) {
-			wishLists.forEach(wishList -> {
-				wishList.updateChecked(true);
+		if (carts.stream().anyMatch(cart -> cart.isChecked() == false)) {
+			carts.forEach(cart -> {
+				cart.updateChecked(true);
 			});
 		} else {
-			wishLists.forEach(wishList -> {
-				wishList.updateChecked(false);
+			carts.forEach(cart -> {
+				cart.updateChecked(false);
 			});
 		}
 
@@ -169,22 +169,22 @@ public class CartServiceImpl implements CartService {
 	@Override
 	public void addWishListAtProductPage(CartRequestDto wishListRequestDto, int quantity) {
 
-		List<WishList> wishLists = wishListRepository.findByMemberUuid(wishListRequestDto.getMemberUuid());
+		List<Cart> carts = wishListRepository.findByMemberUuid(wishListRequestDto.getMemberUuid());
 
 		// memberUuid에 대해 productUuid는 최대 20개까지 추가 가능
-		if (wishLists.size() >= 20) {
+		if (carts.size() >= 20) {
 			throw new RuntimeException("하나의 memberUuid에 대해 최대 20개까지 상품을 추가할 수 있습니다.");
 		}
 
-		Optional<WishList> existingWishList = wishListRepository.findByMemberUuidAndProductUuid(
+		Optional<Cart> existingWishList = wishListRepository.findByMemberUuidAndProductUuid(
 			wishListRequestDto.getMemberUuid(),
 			wishListRequestDto.getProductUuid());
 
 		if (existingWishList.isPresent()) {
-			WishList wishList = existingWishList.get();
-			if (wishList.getCurrentQuantity() + quantity <= wishList.getLimitQuantity()) {
-				wishList.updateCurrentQuantity(wishList.getCurrentQuantity() + quantity);
-				wishListRepository.save(wishList);
+			Cart cart = existingWishList.get();
+			if (cart.getCurrentQuantity() + quantity <= cart.getLimitQuantity()) {
+				cart.updateCurrentQuantity(cart.getCurrentQuantity() + quantity);
+				wishListRepository.save(cart);
 			} else {
 				throw new RuntimeException("상품의 최대 수량을 초과할 수 없습니다.");
 			}
@@ -198,31 +198,31 @@ public class CartServiceImpl implements CartService {
 	@Override
 	public TotalInfoResponseDto getWishListTotalPriceAndDiscount(String memberUuid) {
 		// 회원의 장바구니 레포지토리에서 is_checked가 true인 상품들을 가져와서 다른 레포지토리에 그 상품에 대한 가격과 할인값을 가져와서 총 계산
-		List<WishList> wishLists = wishListRepository.findByMemberUuid(memberUuid);
+		List<Cart> carts = wishListRepository.findByMemberUuid(memberUuid);
 
 		int totalPrice = 0;
 		int totalDiscount = 0;
 
-		for (WishList wishList : wishLists) {
-			if (wishList.isChecked() == true) {
-				ProductDetails details = productDetailsRepository.findByProductUuid(wishList.getProductUuid())
+		for (Cart cart : carts) {
+			if (cart.isChecked() == true) {
+				ProductDetails details = productDetailsRepository.findByProductUuid(cart.getProductUuid())
 					.orElseThrow(
-						() -> new RuntimeException("Product not found for UUID: " + wishList.getProductUuid()));
+						() -> new RuntimeException("Product not found for UUID: " + cart.getProductUuid()));
 
 				int productPrice = details.getProductPrice();
 
-				log.info("productPriceInfo: {}, {}개", productPrice, wishList.getCurrentQuantity());
-				totalPrice += productPrice * wishList.getCurrentQuantity();
+				log.info("productPriceInfo: {}, {}개", productPrice, cart.getCurrentQuantity());
+				totalPrice += productPrice * cart.getCurrentQuantity();
 
 				if (discountRepository.findByProductUuid(
-					wishList.getProductUuid()).isPresent()) {
+					cart.getProductUuid()).isPresent()) {
 					ProductDefaultDisCount productDefaultDisCount = discountRepository.findByProductUuid(
-						wishList.getProductUuid()).get();
+						cart.getProductUuid()).get();
 
 					int productDiscount = productDefaultDisCount.getDiscountValue();
 					log.info("할인률: {}", productDiscount);
 					log.info("할인금액: {}", (productPrice * (productDiscount * 0.01)));
-					totalDiscount += (productPrice * (productDiscount * 0.01)) * wishList.getCurrentQuantity();
+					totalDiscount += (productPrice * (productDiscount * 0.01)) * cart.getCurrentQuantity();
 				}
 
 			}

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/service/CartServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/service/CartServiceImpl.java
@@ -1,4 +1,4 @@
-package starbucks3355.starbucksServer.domainWishList.service;
+package starbucks3355.starbucksServer.domainCart.service;
 
 import java.util.Comparator;
 import java.util.List;
@@ -9,34 +9,34 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import starbucks3355.starbucksServer.domainCart.dto.in.CartRequestDto;
+import starbucks3355.starbucksServer.domainCart.dto.out.CartResponseDto;
+import starbucks3355.starbucksServer.domainCart.dto.out.TotalInfoResponseDto;
+import starbucks3355.starbucksServer.domainCart.entity.WishList;
+import starbucks3355.starbucksServer.domainCart.repository.CartRepository;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDefaultDisCount;
 import starbucks3355.starbucksServer.domainProduct.entity.ProductDetails;
 import starbucks3355.starbucksServer.domainProduct.repository.DiscountRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductDetailsRepository;
-import starbucks3355.starbucksServer.domainWishList.dto.in.WishListRequestDto;
-import starbucks3355.starbucksServer.domainWishList.dto.out.TotalInfoResponseDto;
-import starbucks3355.starbucksServer.domainWishList.dto.out.WishListResponseDto;
-import starbucks3355.starbucksServer.domainWishList.entity.WishList;
-import starbucks3355.starbucksServer.domainWishList.repository.WishListRepository;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class WishListServiceImpl implements WishListService {
-	private final WishListRepository wishListRepository;
+public class CartServiceImpl implements CartService {
+	private final CartRepository wishListRepository;
 
 	private final ProductDetailsRepository productDetailsRepository;
 
 	private final DiscountRepository discountRepository;
 
 	@Override
-	public List<WishListResponseDto> getMyWishListItems(String memberUuid) {
+	public List<CartResponseDto> getMyWishListItems(String memberUuid) {
 		List<WishList> myWishList = wishListRepository.findByMemberUuid(memberUuid);
 
 		if (myWishList != null) {
 			return myWishList.stream()
 				.sorted(Comparator.comparing(WishList::getModDate).reversed())
-				.map(myWishListItem -> WishListResponseDto.builder()
+				.map(myWishListItem -> CartResponseDto.builder()
 					.productUuid(myWishListItem.getProductUuid())
 					.memberUuid(myWishListItem.getMemberUuid())
 					.isChecked(
@@ -52,7 +52,7 @@ public class WishListServiceImpl implements WishListService {
 	}
 
 	@Override
-	public void addWishList(WishListRequestDto wishListRequestDto) {
+	public void addWishList(CartRequestDto wishListRequestDto) {
 		wishListRepository.save(
 			wishListRequestDto.toEntity(wishListRequestDto.getProductUuid(), wishListRequestDto.getMemberUuid()));
 	}
@@ -167,7 +167,7 @@ public class WishListServiceImpl implements WishListService {
 	// }
 
 	@Override
-	public void addWishListAtProductPage(WishListRequestDto wishListRequestDto, int quantity) {
+	public void addWishListAtProductPage(CartRequestDto wishListRequestDto, int quantity) {
 
 		List<WishList> wishLists = wishListRepository.findByMemberUuid(wishListRequestDto.getMemberUuid());
 

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/vo/in/CartRequestVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/vo/in/CartRequestVo.java
@@ -1,4 +1,4 @@
-package starbucks3355.starbucksServer.domainWishList.vo.in;
+package starbucks3355.starbucksServer.domainCart.vo.in;
 
 import java.time.LocalDateTime;
 
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class WishListRequestVo {
+public class CartRequestVo {
 	private String productUuid;
 	//private String memberUuid;
 	private boolean isChecked;

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/vo/out/CartResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/vo/out/CartResponseVo.java
@@ -1,4 +1,4 @@
-package starbucks3355.starbucksServer.domainWishList.vo.out;
+package starbucks3355.starbucksServer.domainCart.vo.out;
 
 import java.time.LocalDateTime;
 
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class WishListResponseVo {
+public class CartResponseVo {
 	private String productUuid;
 	private String memberUuid;
 	private boolean isChecked;

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/vo/out/TotalInfoResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/vo/out/TotalInfoResponseVo.java
@@ -1,4 +1,4 @@
-package starbucks3355.starbucksServer.domainWishList.vo.out;
+package starbucks3355.starbucksServer.domainCart.vo.out;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/starbucks3355/starbucksServer/domainImage/controller/ImageController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainImage/controller/ImageController.java
@@ -32,7 +32,7 @@ import starbucks3355.starbucksServer.domainImage.vo.out.ImageResponseVo;
 public class ImageController {
 	private final ImageService imageService;
 
-	@GetMapping("/allMedias/{otherUuid}")
+	@GetMapping("/{otherUuid}/allMedias")
 	@Operation(summary = "개체(상품, 리뷰, 쿠폰)에 대한 목록 이미지 조회")
 	public CommonResponseEntity<List<ImageResponseVo>> getImages(
 		@PathVariable String otherUuid
@@ -48,7 +48,7 @@ public class ImageController {
 		);
 	}
 
-	@GetMapping("/mainMedia/{otherUuid}")
+	@GetMapping("/{otherUuid}/mainMedia")
 	@Operation(summary = "개체(상품, 리뷰, 쿠폰)에 대한 메인 이미지 조회")
 	public CommonResponseEntity<ImageResponseVo> getMainImage(
 		@PathVariable String otherUuid
@@ -62,7 +62,7 @@ public class ImageController {
 		);
 	}
 
-	@PostMapping("/addMedia/{otherUuid}")
+	@PostMapping("/{otherUuid}/addMedia")
 	@Operation(summary = "개체(상품, 리뷰, 쿠폰)에 대한 이미지 추가")
 	public CommonResponseEntity<Void> addImages(
 		@RequestBody List<ImageRequestVo> imageRequestVoList,
@@ -80,7 +80,7 @@ public class ImageController {
 		);
 	}
 
-	@DeleteMapping("/deleteMedia/{id}/{otherUuid}")
+	@DeleteMapping("/{otherUuid}/deleteMedia/{id}")
 	@Operation(summary = "개체(상품, 리뷰, 쿠폰)에 대한 이미지 삭제")
 	public CommonResponseEntity<Void> deleteImage(
 		@PathVariable Long id, String otherUuid,
@@ -95,7 +95,7 @@ public class ImageController {
 		);
 	}
 
-	@DeleteMapping("/deleteAllMedia/{otherUuid}")
+	@DeleteMapping("/{otherUuid}/deleteAllMedia")
 	// 개체(상품, 리뷰, 쿠폰)에 대한 모든 이미지 삭제(수정의 경우 기존 등록된 모든 이미지리스트를 삭제하고 새 리스트을 입력할 것)
 	@Operation(summary = "개체(상품, 리뷰, 쿠폰)에 대한 모든 이미지 삭제")
 	public CommonResponseEntity<Void> deleteAllImage(

--- a/src/main/java/starbucks3355/starbucksServer/domainImage/entity/Image.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainImage/entity/Image.java
@@ -24,7 +24,7 @@ public class Image {
 	@Column(nullable = false, length = 200)
 	private String s3url;
 	@Column(nullable = false, length = 200, unique = true)
-	private String imageName;
+	private String imageName; // 삭제될 수도 있는 컬럼
 	@Column(length = 250)
 	private String thumbnailPath;
 	@Column(nullable = false)

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
@@ -21,13 +21,11 @@ import starbucks3355.starbucksServer.common.entity.CommonResponseSliceEntity;
 import starbucks3355.starbucksServer.common.utils.CursorPage;
 import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
-import starbucks3355.starbucksServer.domainProduct.dto.response.ProductInfoResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductsResponseDto;
 import starbucks3355.starbucksServer.domainProduct.service.ProductService;
 import starbucks3355.starbucksServer.domainProduct.vo.response.DiscountResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductDetailsPriceResponseVo;
-import starbucks3355.starbucksServer.domainProduct.vo.response.ProductInfoResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductsResponseVo;
 
@@ -114,22 +112,22 @@ public class ProductController {
 		);
 	}
 
-	@GetMapping("/search/{searchInfo}")
-	@Operation(summary = "상품 검색(상품명, 태그)을 통힌 정보 조회")
-	public CommonResponseEntity<List<ProductInfoResponseVo>> getProductSearchInfo(
-		@PathVariable String searchInfo
-	) {
-		List<ProductInfoResponseDto> productsInfoDtoList = productService.getProductsInfo(searchInfo);
-
-		List<ProductInfoResponseVo> productsInfoVoList = productsInfoDtoList.stream()
-			.map(ProductInfoResponseDto::dtoToResponseVo)
-			.collect(Collectors.toList());
-
-		return new CommonResponseEntity<>(
-			HttpStatus.OK,
-			CommonResponseMessage.SUCCESS.getMessage(),
-			productsInfoVoList
-		);
-	}
+	// @GetMapping("/search/{searchInfo}")
+	// @Operation(summary = "상품 검색(상품명, 태그)을 통힌 정보 조회")
+	// public CommonResponseEntity<List<ProductInfoResponseVo>> getProductSearchInfo(
+	// 	@PathVariable String searchInfo
+	// ) {
+	// 	List<ProductInfoResponseDto> productsInfoDtoList = productService.getProductsInfo(searchInfo);
+	//
+	// 	List<ProductInfoResponseVo> productsInfoVoList = productsInfoDtoList.stream()
+	// 		.map(ProductInfoResponseDto::dtoToResponseVo)
+	// 		.collect(Collectors.toList());
+	//
+	// 	return new CommonResponseEntity<>(
+	// 		HttpStatus.OK,
+	// 		CommonResponseMessage.SUCCESS.getMessage(),
+	// 		productsInfoVoList
+	// 	);
+	// }
 
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
@@ -5,8 +5,11 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,15 +18,20 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import starbucks3355.starbucksServer.auth.entity.AuthUserDetail;
+import starbucks3355.starbucksServer.common.entity.BaseResponse;
+import starbucks3355.starbucksServer.common.entity.BaseResponseStatus;
 import starbucks3355.starbucksServer.common.entity.CommonResponseEntity;
 import starbucks3355.starbucksServer.common.entity.CommonResponseMessage;
 import starbucks3355.starbucksServer.common.entity.CommonResponseSliceEntity;
 import starbucks3355.starbucksServer.common.utils.CursorPage;
+import starbucks3355.starbucksServer.domainProduct.dto.request.ProductRequestDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductsResponseDto;
 import starbucks3355.starbucksServer.domainProduct.service.ProductService;
+import starbucks3355.starbucksServer.domainProduct.vo.request.ProductRequestVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.DiscountResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductDetailsPriceResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductResponseVo;
@@ -129,5 +137,19 @@ public class ProductController {
 	// 		productsInfoVoList
 	// 	);
 	// }
+
+	@PostMapping("/add")
+	@Operation(summary = "상품 추가")
+	public BaseResponse<Void> addProduct(
+		@AuthenticationPrincipal AuthUserDetail authUserDetail,
+		@RequestBody ProductRequestVo productRequestVo
+	) {
+		
+		productService.addProduct(ProductRequestDto.of(productRequestVo));
+
+		return new BaseResponse<>(
+			BaseResponseStatus.SUCCESS
+		);
+	}
 
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
@@ -52,7 +52,7 @@ public class ProductController {
 		);
 	}
 
-	@GetMapping("/productDetails/{productUuid}")
+	@GetMapping("/{productUuid}/productDetails")
 	@Operation(summary = "상품 가격만 조회")
 	public CommonResponseEntity<ProductDetailsPriceResponseVo> getProductDetails(
 		@PathVariable String productUuid) {
@@ -65,7 +65,7 @@ public class ProductController {
 		);
 	}
 
-	@GetMapping
+	@GetMapping("/listWithPageable")
 	@Operation(summary = "상품 목록 조회 (무한 스크롤 페이지 처리)")
 	public CommonResponseSliceEntity<List<ProductsResponseVo>> getProducts(
 
@@ -86,7 +86,7 @@ public class ProductController {
 		);
 	}
 
-	@GetMapping("/list")
+	@GetMapping("/listWithQueryDSL")
 	@Operation(summary = "상품 목록 조회 2 (커서 페이지 처리)")
 	public CommonResponseEntity<CursorPage<String>> getProducts(
 		@RequestParam(value = "lastId", required = false) Long lastId,
@@ -101,7 +101,7 @@ public class ProductController {
 		);
 	}
 
-	@GetMapping("/productDiscountInfo/{productUuid}")
+	@GetMapping("/{productUuid}/productDiscountInfo")
 	@Operation(summary = "상품 할인 정보 조회")
 	public CommonResponseEntity<DiscountResponseVo> getProductRateDiscountInfo(
 		@PathVariable String productUuid) {

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/request/ProductRequestDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/request/ProductRequestDto.java
@@ -2,10 +2,12 @@ package starbucks3355.starbucksServer.domainProduct.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import starbucks3355.starbucksServer.domainProduct.entity.Product;
 import starbucks3355.starbucksServer.domainProduct.vo.request.ProductRequestVo;
 
 @Getter
+@NoArgsConstructor
 public class ProductRequestDto {
 	private String productUuid;
 	private String productName;

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/Product.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/Product.java
@@ -9,12 +9,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import starbucks3355.starbucksServer.common.entity.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @ToString
-public class Product {
+public class Product extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -33,6 +34,7 @@ public class Product {
 		this.productName = productName;
 		this.productDescription = productDescription;
 		this.productInfo = productInfo;
+
 	}
 
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,9 +11,7 @@ import lombok.ToString;
 
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 @ToString
 public class ProductFlags {
 	@Id
@@ -26,4 +23,19 @@ public class ProductFlags {
 	private boolean isBest;
 	@Column(nullable = false)
 	private String productUuid;
+
+	@Builder
+	public ProductFlags(Long id, boolean isNew, boolean isBest, String productUuid) {
+		this.id = id;
+		this.isNew = isNew;
+		this.isBest = isBest;
+		this.productUuid = productUuid;
+	}
+
+	@Builder
+	public ProductFlags(boolean isNew, boolean isBest, String productUuid) {
+		this.isNew = isNew;
+		this.isBest = isBest;
+		this.productUuid = productUuid;
+	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/FlagsRepositoryCustom.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/FlagsRepositoryCustom.java
@@ -1,0 +1,9 @@
+package starbucks3355.starbucksServer.domainProduct.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FlagsRepositoryCustom {
+	// 등록 메서드
+	public void saveFlags(String productUuid);
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/FlagsRepositoryCustomImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/FlagsRepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package starbucks3355.starbucksServer.domainProduct.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import starbucks3355.starbucksServer.domainProduct.entity.QProduct;
+
+@Repository
+@RequiredArgsConstructor
+public class FlagsRepositoryCustomImpl implements FlagsRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public void saveFlags(String productUuid) {
+		// isBest: 상품이 베스트 기준을 만족하는 상품이면 true
+		// isNew: 상품의 uuid을 통해 상품의 등록시간이 최신 10개에 속하면 true 로 설정하는 메서드
+		QProduct qProduct = QProduct.product;
+		BooleanBuilder builder = new BooleanBuilder();
+
+		// 상품의 등록시간이 최신 10개에 속하면 true 로 설정
+		boolean isNew = queryFactory
+			.select(qProduct.productUuid)
+			.from(qProduct)
+			.orderBy(qProduct.regDate.desc())
+			.limit(10)
+			.fetch()
+			.contains(productUuid);
+
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
@@ -1,7 +1,5 @@
 package starbucks3355.starbucksServer.domainProduct.service;
 
-import java.util.List;
-
 import org.springframework.data.domain.Slice;
 
 import starbucks3355.starbucksServer.common.utils.CursorPage;
@@ -9,7 +7,6 @@ import starbucks3355.starbucksServer.domainProduct.dto.request.ProductRequestDto
 import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductFlagsResponseDto;
-import starbucks3355.starbucksServer.domainProduct.dto.response.ProductInfoResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductsResponseDto;
 
@@ -31,7 +28,7 @@ public interface ProductService {
 
 	public ProductResponseDto getProduct(String productUuid);
 
-	public List<ProductInfoResponseDto> getProductsInfo(String productSearchInfo);
+	// public List<ProductInfoResponseDto> getProductsInfo(String productSearchInfo);
 
 	public ProductDetailsPriceResponseDto getProductPrice(String productUuid);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
@@ -1,6 +1,5 @@
 package starbucks3355.starbucksServer.domainProduct.service;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.PageRequest;
@@ -15,11 +14,9 @@ import starbucks3355.starbucksServer.domainProduct.dto.request.ProductRequestDto
 import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductFlagsResponseDto;
-import starbucks3355.starbucksServer.domainProduct.dto.response.ProductInfoResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductsResponseDto;
 import starbucks3355.starbucksServer.domainProduct.entity.Product;
-import starbucks3355.starbucksServer.domainProduct.entity.ProductTag;
 import starbucks3355.starbucksServer.domainProduct.repository.DiscountRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.FlagsRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductDetailsRepository;
@@ -91,27 +88,27 @@ public class ProductServiceImpl implements ProductService {
 
 	}
 
-	@Override
-	public List<ProductInfoResponseDto> getProductsInfo(String productSearchInfo) {
-		// 검색어 첫글자가 # 이면 findByTagNameContaining, 이외에는 findByProductNameContaining
-		// 상품의 이름이나 태그를 통해서 상품의 uuid 값 반환
-		if (productSearchInfo.startsWith("#")) {
-			List<ProductTag> tagUuidList = productTagRepository.findByTagNameContaining(productSearchInfo);
-			return tagUuidList.stream()
-				.map(tagOfProductUuid -> ProductInfoResponseDto.builder()
-					.productUuid(tagOfProductUuid.getProductUuid())
-					.build()
-				).toList();
-
-		} // else 사용할 이유가 없음, if 에서 미리 반환됨, 검색 로직 개선
-		List<Product> nameUuidList = productRepository.findByProductNameContaining(productSearchInfo);
-		return nameUuidList.stream()
-			.map(nameOfProductUuid -> ProductInfoResponseDto.builder()
-				.productUuid(nameOfProductUuid.getProductUuid())
-				.build()
-			).toList();
-
-	}
+	// @Override
+	// public List<ProductInfoResponseDto> getProductsInfo(String productSearchInfo) {
+	// 	// 검색어 첫글자가 # 이면 findByTagNameContaining, 이외에는 findByProductNameContaining
+	// 	// 상품의 이름이나 태그를 통해서 상품의 uuid 값 반환
+	// 	if (productSearchInfo.startsWith("#")) {
+	// 		List<ProductTag> tagUuidList = productTagRepository.findByTagNameContaining(productSearchInfo);
+	// 		return tagUuidList.stream()
+	// 			.map(tagOfProductUuid -> ProductInfoResponseDto.builder()
+	// 				.productUuid(tagOfProductUuid.getProductUuid())
+	// 				.build()
+	// 			).toList();
+	//
+	// 	} // else 사용할 이유가 없음, if 에서 미리 반환됨, 검색 로직 개선
+	// 	List<Product> nameUuidList = productRepository.findByProductNameContaining(productSearchInfo);
+	// 	return nameUuidList.stream()
+	// 		.map(nameOfProductUuid -> ProductInfoResponseDto.builder()
+	// 			.productUuid(nameOfProductUuid.getProductUuid())
+	// 			.build()
+	// 		).toList();
+	//
+	// }
 
 	@Override
 	public ProductDetailsPriceResponseDto getProductPrice(String productUuid) {

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
@@ -38,8 +38,8 @@ public class ProductServiceImpl implements ProductService {
 
 	@Override
 	public void addProduct(ProductRequestDto productRequestDto) {
-		// 관리자 기능이기에 제외
-		productRepository.save(productRequestDto.dtoToEntity(UUID.randomUUID().toString()));
+		Product product = productRequestDto.dtoToEntity(UUID.randomUUID().toString());
+		productRepository.save(product);
 	}
 
 	@Override

--- a/src/main/java/starbucks3355/starbucksServer/domainPromotion/controller/PromotionController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainPromotion/controller/PromotionController.java
@@ -46,7 +46,7 @@ public class PromotionController {
 	}
 
 	// 기획전의 uuid를 받아 기획전 명을 조회
-	@GetMapping("/name/{promotionUuid}")
+	@GetMapping("/{promotionUuid}/name")
 	@Operation(summary = "기획전 이름 조회")
 	public BaseResponse<PromotionNameResponseVo> getPromotionName(
 		@PathVariable String promotionUuid

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
@@ -28,6 +28,7 @@ import starbucks3355.starbucksServer.common.entity.CommonResponseSliceEntity;
 import starbucks3355.starbucksServer.common.utils.CursorPage;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
+import starbucks3355.starbucksServer.domainReview.dto.out.BestReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
@@ -82,20 +83,17 @@ public class ReviewController {
 		);
 	}
 
-	// @GetMapping("/{productUuid}/bestReviewsOfProduct")
-	// @Operation(summary = "상품별 베스트 리뷰 조회")
-	// public CommonResponseEntity<List<ReviewResponseVo>> getBestReviews(
-	// 	@PathVariable String productUuid) {
-	// 	List<ReviewResponseDto> bestReviewsDto = reviewService.getBestReviews(productUuid);
-	//
-	// 	return new CommonResponseEntity<>(
-	// 		HttpStatus.OK,
-	// 		CommonResponseMessage.SUCCESS.getMessage(),
-	// 		bestReviewsDto.stream()
-	// 			.map(ReviewResponseDto::dtoToResponseVo)
-	// 			.toList()
-	// 	);
-	// }
+	@GetMapping("/bestReviews")
+	@Operation(summary = "전체 리뷰들 중 베스트 리뷰 조회")
+	public BaseResponse<CursorPage<BestReviewResponseDto>> getBestReviews(
+		@RequestParam(value = "lastId", required = false) Long lastId,
+		@RequestParam(value = "pageSize", required = false) Integer pageSize,
+		@RequestParam(value = "page", required = false) Integer page) {
+
+		return new BaseResponse<>(
+			reviewService.getBestReviews(lastId, pageSize, page)
+		);
+	}
 
 	@GetMapping("/allReviewsOfMyPage")
 	@Operation(summary = "나의 리뷰 전체 조회")

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
@@ -118,7 +118,7 @@ public class ReviewController {
 
 	}
 
-	@GetMapping("/allReviewsOfUser/{authorName}")
+	@GetMapping("/{authorName}/allReviewsOfUser")
 	@Operation(summary = "작성자의 리뷰 전체 조회")
 	// 상품상세 페이지에서 이용할 용도(페이지 생성여부에 따라 갈림)
 	public CommonResponseEntity<List<UserReviewResponseVo>> getUserReviews(
@@ -202,7 +202,7 @@ public class ReviewController {
 
 	}
 
-	@DeleteMapping("/reviewDelete/{id}")
+	@DeleteMapping("/{id}/reviewDelete")
 	@Operation(summary = "댓글 삭제", description = "작성했던 리뷰를 삭제합니다.")
 	public CommonResponseEntity<Void> deleteReview(
 		@AuthenticationPrincipal AuthUserDetail authUserDetail,

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
@@ -82,29 +82,31 @@ public class ReviewController {
 		);
 	}
 
-	@GetMapping("/{productUuid}/bestReviewsOfProduct")
-	@Operation(summary = "상품별 베스트 리뷰 조회")
-	public CommonResponseEntity<List<ReviewResponseVo>> getBestReviews(
-		@PathVariable String productUuid) {
-		List<ReviewResponseDto> bestReviewsDto = reviewService.getBestReviews(productUuid);
-
-		return new CommonResponseEntity<>(
-			HttpStatus.OK,
-			CommonResponseMessage.SUCCESS.getMessage(),
-			bestReviewsDto.stream()
-				.map(ReviewResponseDto::dtoToResponseVo)
-				.toList()
-		);
-	}
+	// @GetMapping("/{productUuid}/bestReviewsOfProduct")
+	// @Operation(summary = "상품별 베스트 리뷰 조회")
+	// public CommonResponseEntity<List<ReviewResponseVo>> getBestReviews(
+	// 	@PathVariable String productUuid) {
+	// 	List<ReviewResponseDto> bestReviewsDto = reviewService.getBestReviews(productUuid);
+	//
+	// 	return new CommonResponseEntity<>(
+	// 		HttpStatus.OK,
+	// 		CommonResponseMessage.SUCCESS.getMessage(),
+	// 		bestReviewsDto.stream()
+	// 			.map(ReviewResponseDto::dtoToResponseVo)
+	// 			.toList()
+	// 	);
+	// }
 
 	@GetMapping("/allReviewsOfMyPage")
 	@Operation(summary = "나의 리뷰 전체 조회")
 	public CommonResponseEntity<List<UserReviewResponseVo>> getMemberReviews(
 		@AuthenticationPrincipal AuthUserDetail authUserDetail) {
 
-		String memberUuid = authUserDetail.getUuid(); // 로그인된 사용자의 UUID 가져오기
+		// 로그인된 사용자의 UUID 가져와서 그 사용자의 닉네임 찾기
+		String username = authUserDetail.getUsername();
 
-		List<UserReviewResponseDto> memberReviewsDto = reviewService.getUserReviews(memberUuid);
+		// 수정 필요
+		List<UserReviewResponseDto> memberReviewsDto = reviewService.getUserReviews(username);
 
 		return new CommonResponseEntity<>(
 			HttpStatus.OK,

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
@@ -25,6 +25,7 @@ import starbucks3355.starbucksServer.common.entity.BaseResponseStatus;
 import starbucks3355.starbucksServer.common.entity.CommonResponseEntity;
 import starbucks3355.starbucksServer.common.entity.CommonResponseMessage;
 import starbucks3355.starbucksServer.common.entity.CommonResponseSliceEntity;
+import starbucks3355.starbucksServer.common.utils.CursorPage;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
@@ -68,19 +69,16 @@ public class ReviewController {
 		);
 	}
 
-	@GetMapping("/{productUuid}/allReviewsHaveMediaOfProduct")
+	@GetMapping("/allReviewsHaveMediaOfProduct")
 	@Operation(summary = "상품별 리뷰 전체 조회(이미지가 있는 리뷰만)")
-	public CommonResponseEntity<List<ReviewProductResponseVo>> getProductReviewsHaveMedia(
-		@PathVariable String productUuid) {
-		List<ReviewProductResponseDto> productReviewResponseDtoList = reviewService.getProductReviewsHaveMedia(
-			productUuid);
+	public BaseResponse<CursorPage<String>> getProductReviewsHaveMedia(
+		@RequestParam(value = "productUuid") String productUuid,
+		@RequestParam(value = "lastId", required = false) Long lastId,
+		@RequestParam(value = "pageSize", required = false) Integer pageSize,
+		@RequestParam(value = "page", required = false) Integer page) {
 
-		return new CommonResponseEntity<>(
-			HttpStatus.OK,
-			CommonResponseMessage.SUCCESS.getMessage(),
-			productReviewResponseDtoList.stream()
-				.map(ReviewProductResponseDto::dtoToResponseVo)
-				.toList()
+		return new BaseResponse<>(
+			reviewService.getProductReviewsHaveMedia(productUuid, lastId, pageSize, page)
 		);
 	}
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewAggregateRequestDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewAggregateRequestDto.java
@@ -1,0 +1,4 @@
+package starbucks3355.starbucksServer.domainReview.dto.in;
+
+public class ReviewAggregateRequestDto {
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewRequestDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewRequestDto.java
@@ -31,7 +31,7 @@ public class ReviewRequestDto {
 			.reviewScore(reviewScore)
 			.productUuid(productUuid)
 			.authorName(authorName)
-			.reviewViewCount(0)
+			//.reviewViewCount(0)
 			.build();
 	}
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/dto/out/BestReviewResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/dto/out/BestReviewResponseDto.java
@@ -1,0 +1,28 @@
+package starbucks3355.starbucksServer.domainReview.dto.out;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import starbucks3355.starbucksServer.domainReview.vo.out.BestReviewResponseVo;
+
+@Getter
+@NoArgsConstructor
+public class BestReviewResponseDto {
+	private String reviewUuid;
+	private String productUuid;
+
+	@Builder
+	public BestReviewResponseDto(
+		String reviewUuid,
+		String productUuid) {
+		this.reviewUuid = reviewUuid;
+		this.productUuid = productUuid;
+	}
+
+	public BestReviewResponseVo dtoToResponseVo() {
+		return BestReviewResponseVo.builder()
+			.reviewUuid(reviewUuid)
+			.productUuid(productUuid)
+			.build();
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/dto/out/ReviewResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/dto/out/ReviewResponseDto.java
@@ -4,15 +4,18 @@ import java.time.LocalDateTime;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import starbucks3355.starbucksServer.domainReview.entity.Review;
 import starbucks3355.starbucksServer.domainReview.vo.out.ReviewResponseVo;
 
 @Getter
-@Builder
+@NoArgsConstructor
 public class ReviewResponseDto { // 상품 한개에 대한 리뷰 응답 dto
 	private String content;
 	private Integer reivewScore;
 	private LocalDateTime regDate, modDate;
 
+	@Builder
 	public ReviewResponseDto(
 		String content,
 		Integer reivewScore,
@@ -22,6 +25,15 @@ public class ReviewResponseDto { // 상품 한개에 대한 리뷰 응답 dto
 		this.reivewScore = reivewScore;
 		this.regDate = regDate;
 		this.modDate = modDate;
+	}
+
+	public static ReviewResponseDto from(Review review) {
+		return ReviewResponseDto.builder()
+			.content(review.getContent())
+			.reivewScore(review.getReviewScore())
+			.regDate(review.getRegDate())
+			.modDate(review.getModDate())
+			.build();
 	}
 
 	public ReviewResponseVo dtoToResponseVo() {

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/dto/out/ReviewScoreResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/dto/out/ReviewScoreResponseDto.java
@@ -1,0 +1,27 @@
+package starbucks3355.starbucksServer.domainReview.dto.out;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import starbucks3355.starbucksServer.domainReview.vo.out.ReviewScoreResponseVo;
+
+@Getter
+@NoArgsConstructor
+public class ReviewScoreResponseDto {
+	String reviewscoreAvg;
+	String reviewcount;
+
+	@Builder
+	public ReviewScoreResponseDto(String reviewscoreAvg, String reviewcount) {
+		this.reviewscoreAvg = reviewscoreAvg;
+		this.reviewcount = reviewcount;
+	}
+
+	public ReviewScoreResponseVo dtoToResponseVo() {
+		return ReviewScoreResponseVo.builder()
+			.reviewscoreAvg(reviewscoreAvg)
+			.reviewcount(reviewcount)
+			.build();
+	}
+
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/entity/Review.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/entity/Review.java
@@ -28,18 +28,23 @@ public class Review extends BaseEntity {
 	private String productUuid; // 상품의 정보가 너무 많기에, 매핑 테이블 요구됨
 	@Column(nullable = false)
 	private String authorName; // 액세스 토큰에서 받은 uuid값을 가공해서 삽입 <- 닉네임으로 할 경우 변경시 문제 발생
-	@Column
-	private Integer reviewViewCount; // 조회수 -> 동시성문제, 집계테이블 필요, 베스트는 db의 더미깂 통해 해결
+	// @Column
+	// private Integer reviewViewCount; // 조회수 -> 동시성문제, 집계테이블 필요, 베스트는 db의 더미깂 통해 해결
 
 	@Builder
-	public Review(String content, String reviewUuid, Integer reviewScore, String productUuid, String authorName,
-		Integer reviewViewCount) {
+	public Review(
+		String content,
+		String reviewUuid,
+		Integer reviewScore,
+		String productUuid,
+		String authorName
+	) {
 		this.content = content;
 		this.reviewUuid = reviewUuid;
 		this.reviewScore = reviewScore;
 		this.productUuid = productUuid;
 		this.authorName = authorName;
-		this.reviewViewCount = reviewViewCount;
+		//this.reviewViewCount = reviewViewCount;
 	}
 
 	public void modifyContent(String content) {
@@ -50,8 +55,8 @@ public class Review extends BaseEntity {
 		this.reviewScore = reviewScore;
 	}
 
-	public void modifyReviewViewCount(Integer reviewViewCount) {
-		this.reviewViewCount = reviewViewCount;
-	}
+	// public void modifyReviewViewCount(Integer reviewViewCount) {
+	// 	this.reviewViewCount = reviewViewCount;
+	// }
 
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/entity/ReviewAggregate.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/entity/ReviewAggregate.java
@@ -1,0 +1,55 @@
+package starbucks3355.starbucksServer.domainReview.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@ToString
+public class ReviewAggregate {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String reviewUuid; // 리뷰 UUID
+
+	@Column(nullable = false)
+	private Integer viewCount; // 조회수
+
+	@Column(nullable = false)
+	private Integer reviewScore; // 리뷰 평점
+
+	@Builder
+	public ReviewAggregate(Long id, String reviewUuid, Integer viewCount, Integer reviewScore) {
+		this.id = id;
+		this.reviewUuid = reviewUuid;
+		this.viewCount = viewCount;
+		this.reviewScore = reviewScore;
+	}
+
+	@Builder
+	public ReviewAggregate(String reviewUuid, Integer viewCount, Integer reviewScore) {
+		this.reviewUuid = reviewUuid;
+		this.viewCount = viewCount;
+		this.reviewScore = reviewScore;
+	}
+
+	// 조회수 증가 메서드
+	public ReviewAggregate incrementViewCount() {
+		return ReviewAggregate.builder()
+			.id(this.id)
+			.reviewUuid(this.reviewUuid)
+			.viewCount(this.viewCount + 1) // 조회수 증가
+			.reviewScore(this.reviewScore)
+			.build();
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewAggregateRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewAggregateRepository.java
@@ -1,0 +1,10 @@
+package starbucks3355.starbucksServer.domainReview.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import starbucks3355.starbucksServer.domainReview.entity.ReviewAggregate;
+
+@Repository
+public interface ReviewAggregateRepository extends JpaRepository<ReviewAggregate, Long> {
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepository.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepository.java
@@ -21,7 +21,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 	Slice<Review> findPageByProductUuid(String productUuid, Pageable pageable);
 
 	// 상품의 리뷰들 중 평점이 높고 조회수가 높은 리뷰들을 5개까지 반환
-	List<Review> findTop5ByProductUuidOrderByReviewScoreDescReviewViewCountDesc(String productUuid);
+	// List<Review> findTop5ByProductUuidOrderByReviewScoreDescReviewViewCountDesc(String productUuid);
 
 	boolean existsByReviewUuid(String reviewUuid);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,10 @@
+package starbucks3355.starbucksServer.domainReview.repository;
+
+import org.springframework.stereotype.Repository;
+
+import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
+
+@Repository
+public interface ReviewRepositoryCustom {
+	ReviewScoreResponseDto getReviewScore(String productUuid);
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustom.java
@@ -3,7 +3,9 @@ package starbucks3355.starbucksServer.domainReview.repository;
 import org.springframework.stereotype.Repository;
 
 import starbucks3355.starbucksServer.common.utils.CursorPage;
+import starbucks3355.starbucksServer.domainReview.dto.out.ReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
+import starbucks3355.starbucksServer.domainReview.entity.Review;
 
 @Repository
 public interface ReviewRepositoryCustom {
@@ -15,4 +17,15 @@ public interface ReviewRepositoryCustom {
 		Integer pageSize,
 		Integer page
 	);
+
+	ReviewResponseDto getReviewAndUpdateAggregate(String reviewUuid);
+
+	void updateReviewAggregate(Review review);
+
+	CursorPage<String> getBestReviews(
+		Long lastId,
+		Integer pageSize,
+		Integer page
+	);
+
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustom.java
@@ -3,6 +3,7 @@ package starbucks3355.starbucksServer.domainReview.repository;
 import org.springframework.stereotype.Repository;
 
 import starbucks3355.starbucksServer.common.utils.CursorPage;
+import starbucks3355.starbucksServer.domainReview.dto.out.BestReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
 import starbucks3355.starbucksServer.domainReview.entity.Review;
@@ -22,7 +23,7 @@ public interface ReviewRepositoryCustom {
 
 	void updateReviewAggregate(Review review);
 
-	CursorPage<String> getBestReviews(
+	CursorPage<BestReviewResponseDto> getBestReviews(
 		Long lastId,
 		Integer pageSize,
 		Integer page

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustom.java
@@ -2,9 +2,17 @@ package starbucks3355.starbucksServer.domainReview.repository;
 
 import org.springframework.stereotype.Repository;
 
+import starbucks3355.starbucksServer.common.utils.CursorPage;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
 
 @Repository
 public interface ReviewRepositoryCustom {
 	ReviewScoreResponseDto getReviewScore(String productUuid);
+
+	CursorPage<String> getProductReviewsHaveMedia(
+		String productUuid,
+		Long lastId,
+		Integer pageSize,
+		Integer page
+	);
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustomImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustomImpl.java
@@ -1,18 +1,26 @@
 package starbucks3355.starbucksServer.domainReview.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+import starbucks3355.starbucksServer.common.utils.CursorPage;
+import starbucks3355.starbucksServer.domainImage.entity.QImage;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
 import starbucks3355.starbucksServer.domainReview.entity.QReview;
+import starbucks3355.starbucksServer.domainReview.entity.Review;
 
 @RequiredArgsConstructor
 @Repository
 public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
 
+	private static final int DEFAULT_PAGE_SIZE = 20;
+	private static final int DEFAULT_PAGE_NUMBER = 0;
 	private final JPAQueryFactory jpaQueryFactory;
 
 	@Override
@@ -35,5 +43,59 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
 			.fetchOne().toString();
 
 		return reviewScore == null ? null : new ReviewScoreResponseDto(reviewScore, reviewCount);
+	}
+
+	@Override
+	public CursorPage<String> getProductReviewsHaveMedia(
+		String productUuid,
+		Long lastId,
+		Integer pageSize,
+		Integer page
+	) {
+
+		QReview review = QReview.review;
+		QImage image = QImage.image;
+		BooleanBuilder builder = new BooleanBuilder();
+
+		// 마지막 ID 커서 적용
+		Optional.ofNullable(lastId)
+			.ifPresent(id -> builder.and(review.id.lt(id)));
+
+		// 페이지와 페이지 크기 기본값 설정
+		int currentPage = Optional.ofNullable(page).orElse(DEFAULT_PAGE_NUMBER);
+		int currentPageSize = Optional.ofNullable(pageSize).orElse(DEFAULT_PAGE_SIZE);
+
+		// offset 계산
+		int offset = currentPage == 0 ? 0 : (currentPage - 1) * currentPageSize;
+		// 최신 순 부터 정렬해서 보여주는 정책이기에 (currentPage - 1) * currentPageSize 을 offset(쿼리 결과의 시작 위치를 지정)으로 사용
+
+		List<Review> mediaReviews = jpaQueryFactory
+			.select(review)
+			.from(review)
+			.join(image)
+			.on(review.reviewUuid.eq(image.otherUuid))
+			.where(review.productUuid.eq(productUuid)
+				.and(builder))
+			.orderBy(review.reviewUuid.asc())
+			.limit(currentPageSize + 1)
+			.offset(offset)
+			.fetch();
+
+		// 다음 페이지의 커서 처리 및 hasNext 여부 판단
+		Long nextCursor = null;
+		boolean hasNext = false;
+
+		if (mediaReviews.size() > currentPageSize) {
+			hasNext = true;
+			mediaReviews = mediaReviews.subList(0, currentPageSize);  // 실제 페이지 사이즈 만큼 자르기
+			nextCursor = mediaReviews.get(mediaReviews.size() - 1).getId();  // 마지막 항목의 ID를 커서로 설정
+		}
+
+		List<String> mediaReviewList = mediaReviews.stream()
+			.map(Review::getReviewUuid)
+			.toList();
+
+		return new CursorPage<>(mediaReviewList, nextCursor, hasNext, currentPageSize, currentPage);
+
 	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustomImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/repository/ReviewRepositoryCustomImpl.java
@@ -1,0 +1,39 @@
+package starbucks3355.starbucksServer.domainReview.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
+import starbucks3355.starbucksServer.domainReview.entity.QReview;
+
+@RequiredArgsConstructor
+@Repository
+public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public ReviewScoreResponseDto getReviewScore(String productUuid) {
+		QReview review = QReview.review;
+		BooleanBuilder builder = new BooleanBuilder();
+
+		// 상품의 uuid에 대해 리뷰 점수의 평균 조회
+		String reviewScore = jpaQueryFactory
+			.select(review.reviewScore.avg())
+			.from(review)
+			.where(review.productUuid.eq(productUuid))
+			.fetchOne().toString();
+
+		// 상품의 uuid에 대해 리뷰의 개수 조회
+		String reviewCount = jpaQueryFactory
+			.select(review.reviewUuid.count())
+			.from(review)
+			.where(review.productUuid.eq(productUuid))
+			.fetchOne().toString();
+
+		return reviewScore == null ? null : new ReviewScoreResponseDto(reviewScore, reviewCount);
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
@@ -8,6 +8,7 @@ import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewResponseDto;
+import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.UserReviewResponseDto;
 
 public interface ReviewService {
@@ -18,6 +19,8 @@ public interface ReviewService {
 	public List<ReviewProductResponseDto> getProductReviewsHaveMedia(String productUuid);
 
 	public ReviewResponseDto getReview(String reviewUuid);
+
+	public ReviewScoreResponseDto getReviewScore(String productUuid);
 
 	public List<ReviewResponseDto> getBestReviews(String productUuid);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Slice;
 
+import starbucks3355.starbucksServer.common.utils.CursorPage;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
@@ -16,7 +17,12 @@ public interface ReviewService {
 
 	public Slice<ReviewProductResponseDto> getProductReviews(String productUuid, int page, int size);
 
-	public List<ReviewProductResponseDto> getProductReviewsHaveMedia(String productUuid);
+	CursorPage<String> getProductReviewsHaveMedia(
+		String productUuid,
+		Long lastId,
+		Integer pageSize,
+		Integer page
+	);
 
 	public ReviewResponseDto getReview(String reviewUuid);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Slice;
 import starbucks3355.starbucksServer.common.utils.CursorPage;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
+import starbucks3355.starbucksServer.domainReview.dto.out.BestReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
@@ -29,6 +30,12 @@ public interface ReviewService {
 	public ReviewScoreResponseDto getReviewScore(String productUuid);
 
 	//public List<ReviewResponseDto> getBestReviews(String productUuid);
+
+	CursorPage<BestReviewResponseDto> getBestReviews(
+		Long lastId,
+		Integer pageSize,
+		Integer page
+	);
 
 	void addReview(ReviewRequestDto reviewRequestDto);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewService.java
@@ -28,7 +28,7 @@ public interface ReviewService {
 
 	public ReviewScoreResponseDto getReviewScore(String productUuid);
 
-	public List<ReviewResponseDto> getBestReviews(String productUuid);
+	//public List<ReviewResponseDto> getBestReviews(String productUuid);
 
 	void addReview(ReviewRequestDto reviewRequestDto);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewServiceImpl.java
@@ -18,9 +18,11 @@ import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewResponseDto;
+import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.UserReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.entity.Review;
 import starbucks3355.starbucksServer.domainReview.repository.ReviewRepository;
+import starbucks3355.starbucksServer.domainReview.repository.ReviewRepositoryCustom;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +30,7 @@ public class ReviewServiceImpl implements ReviewService {
 	private final ReviewRepository reviewRepository;
 	private final MemberRepository memberRepository;
 	private final ImageRepository imageRepository;
+	private final ReviewRepositoryCustom reviewRepositoryCustom;
 
 	@Override
 	public List<UserReviewResponseDto> getUserReviews(String authorName) {
@@ -101,6 +104,11 @@ public class ReviewServiceImpl implements ReviewService {
 			.regDate(review.getRegDate())
 			.modDate(review.getModDate())
 			.build();
+	}
+
+	@Override
+	public ReviewScoreResponseDto getReviewScore(String productUuid) {
+		return reviewRepositoryCustom.getReviewScore(productUuid);
 	}
 
 	@Override

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewServiceImpl.java
@@ -15,6 +15,7 @@ import starbucks3355.starbucksServer.common.exception.BaseException;
 import starbucks3355.starbucksServer.common.utils.CursorPage;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
+import starbucks3355.starbucksServer.domainReview.dto.out.BestReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewResponseDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewScoreResponseDto;
@@ -91,6 +92,11 @@ public class ReviewServiceImpl implements ReviewService {
 	@Override
 	public ReviewScoreResponseDto getReviewScore(String productUuid) {
 		return reviewRepositoryCustom.getReviewScore(productUuid);
+	}
+
+	@Override
+	public CursorPage<BestReviewResponseDto> getBestReviews(Long lastId, Integer pageSize, Integer page) {
+		return reviewRepositoryCustom.getBestReviews(lastId, pageSize, page);
 	}
 
 	// @Override

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/service/ReviewServiceImpl.java
@@ -12,8 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import starbucks3355.starbucksServer.common.entity.BaseResponseStatus;
 import starbucks3355.starbucksServer.common.exception.BaseException;
-import starbucks3355.starbucksServer.domainImage.repository.ImageRepository;
-import starbucks3355.starbucksServer.domainMember.repository.MemberRepository;
+import starbucks3355.starbucksServer.common.utils.CursorPage;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewModifyRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.in.ReviewRequestDto;
 import starbucks3355.starbucksServer.domainReview.dto.out.ReviewProductResponseDto;
@@ -28,8 +27,6 @@ import starbucks3355.starbucksServer.domainReview.repository.ReviewRepositoryCus
 @RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService {
 	private final ReviewRepository reviewRepository;
-	private final MemberRepository memberRepository;
-	private final ImageRepository imageRepository;
 	private final ReviewRepositoryCustom reviewRepositoryCustom;
 
 	@Override
@@ -71,26 +68,12 @@ public class ReviewServiceImpl implements ReviewService {
 	}
 
 	@Override
-	public List<ReviewProductResponseDto> getProductReviewsHaveMedia(String productUuid) {
-		List<Review> productReviews = reviewRepository.findByProductUuid(productUuid);
-
-		if (productReviews != null) {
-			// 상품의 리뷰들에 대해 리뷰에 대한 이미지가 한개라도 있으면 리뷰들을 반환
-			return productReviews.stream()
-				.filter(productReview -> imageRepository.findByOtherUuid(productReview.getReviewUuid()).size() > 0)
-				.map(productReview -> ReviewProductResponseDto.builder()
-					.content(productReview.getContent())
-					.reviewScore(productReview.getReviewScore())
-					.reviewUuid(productReview.getReviewUuid())
-					.productUuid(productReview.getProductUuid())
-					.authorName(productReview.getAuthorName())
-					.regDate(productReview.getRegDate())
-					.modDate(productReview.getModDate())
-					.build()
-				).toList();
-
-		}
-		return List.of();
+	public CursorPage<String> getProductReviewsHaveMedia(
+		String productUuid,
+		Long lastId,
+		Integer pageSize,
+		Integer page) {
+		return reviewRepositoryCustom.getProductReviewsHaveMedia(productUuid, lastId, pageSize, page);
 	}
 
 	@Override

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/vo/out/BestReviewResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/vo/out/BestReviewResponseVo.java
@@ -1,0 +1,15 @@
+package starbucks3355.starbucksServer.domainReview.vo.out;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BestReviewResponseVo {
+	private String reviewUuid;
+	private String productUuid;
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/vo/out/ReviewScoreResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/vo/out/ReviewScoreResponseVo.java
@@ -1,0 +1,12 @@
+package starbucks3355.starbucksServer.domainReview.vo.out;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewScoreResponseVo {
+	String reviewscoreAvg;
+	String reviewcount;
+
+}

--- a/src/main/java/starbucks3355/starbucksServer/vendor/controller/ProductListByPromotionController.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/controller/ProductListByPromotionController.java
@@ -46,4 +46,24 @@ public class ProductListByPromotionController {
 
 		);
 	}
+
+	@GetMapping("/{productUuid}/samePromotionProducts")
+	@Operation(summary = "현재 상품과 같은 기획전 인 상품 목록 조회")
+	public BaseResponse<List<ProductListByPromotionResponseVo>> getProductsBySamePromotion(
+		@PathVariable String productUuid
+	) {
+		List<ProductListByPromotionResponseDto> productListByPromotion = productListByPromotionService.getProductsBySamePromotion(
+			productUuid);
+
+		return new BaseResponse<>(
+			HttpStatus.OK,
+			BaseResponseStatus.SUCCESS.isSuccess(),
+			BaseResponseStatus.SUCCESS.getMessage(),
+			BaseResponseStatus.SUCCESS.getCode(),
+			productListByPromotion.stream()
+				.map(ProductListByPromotionResponseDto::dtoToResponseVo)
+				.toList()
+
+		);
+	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/vendor/controller/ProductListByPromotionController.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/controller/ProductListByPromotionController.java
@@ -1,4 +1,4 @@
-package starbucks3355.starbucksServer.vendor.dto.controller;
+package starbucks3355.starbucksServer.vendor.controller;
 
 import java.util.List;
 
@@ -27,7 +27,7 @@ public class ProductListByPromotionController {
 	private final ProductListByPromotionService productListByPromotionService;
 
 	// 기획전의 uuid를 받아 상품 목록을 조회
-	@GetMapping("/product/{promotionUuid}")
+	@GetMapping("/{promotionUuid}/products")
 	@Operation(summary = "기획전별 상품 목록 조회")
 	public BaseResponse<List<ProductListByPromotionResponseVo>> getProductListByPromotion(
 		@PathVariable String promotionUuid

--- a/src/main/java/starbucks3355/starbucksServer/vendor/repository/ProductListByPromotionRepositoryCustom.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/repository/ProductListByPromotionRepositoryCustom.java
@@ -9,4 +9,6 @@ import starbucks3355.starbucksServer.vendor.dto.out.ProductListByPromotionRespon
 @Repository
 public interface ProductListByPromotionRepositoryCustom {
 	List<ProductListByPromotionResponseDto> getProductByPromotionList(String promotionUuid);
+
+	List<ProductListByPromotionResponseDto> getProductsBySamePromotion(String productUuid);
 }

--- a/src/main/java/starbucks3355/starbucksServer/vendor/repository/ProductListByPromotionRepositoryCustomImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/repository/ProductListByPromotionRepositoryCustomImpl.java
@@ -33,4 +33,31 @@ public class ProductListByPromotionRepositoryCustomImpl implements ProductListBy
 			.map(ProductListByPromotionResponseDto::new)
 			.toList();
 	}
+
+	@Override
+	public List<ProductListByPromotionResponseDto> getProductsBySamePromotion(String productUuid) {
+
+		QProductByPromotionList qProductByPromotionList = QProductByPromotionList.productByPromotionList;
+		BooleanBuilder builder = new BooleanBuilder();
+
+		// 상품 uuid를 통해 기획전 uuid를 조회
+		List<String> promotionUuidList = jpaQueryFactory
+			.select(qProductByPromotionList.promotionUuid)
+			.from(qProductByPromotionList)
+			.where(qProductByPromotionList.productUuid.eq(productUuid))
+			.fetch();
+
+		List<String> productUuidList = jpaQueryFactory
+			.select(qProductByPromotionList.productUuid)
+			.from(qProductByPromotionList)
+			.where(qProductByPromotionList.promotionUuid.eq(promotionUuidList.get(0)))
+			.fetch();
+
+		// 현재 상품의 uuid를 제외한 상품 목록을 조회
+		return productUuidList.stream()
+			.filter(uuid -> !uuid.equals(productUuid))
+			.map(ProductListByPromotionResponseDto::new)
+			.toList();
+
+	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/vendor/service/ProductListByPromotionService.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/service/ProductListByPromotionService.java
@@ -7,4 +7,6 @@ import starbucks3355.starbucksServer.vendor.dto.out.ProductListByPromotionRespon
 public interface ProductListByPromotionService {
 	List<ProductListByPromotionResponseDto> getProductListByPromotion(String promotionUuid);
 
+	List<ProductListByPromotionResponseDto> getProductsBySamePromotion(String productUuid);
+
 }

--- a/src/main/java/starbucks3355/starbucksServer/vendor/service/ProductListByPromotionServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/service/ProductListByPromotionServiceImpl.java
@@ -19,4 +19,9 @@ public class ProductListByPromotionServiceImpl implements ProductListByPromotion
 	public List<ProductListByPromotionResponseDto> getProductListByPromotion(String promotionUuid) {
 		return productListByPromotionRepositoryCustom.getProductByPromotionList(promotionUuid);
 	}
+
+	@Override
+	public List<ProductListByPromotionResponseDto> getProductsBySamePromotion(String productUuid) {
+		return productListByPromotionRepositoryCustom.getProductsBySamePromotion(productUuid);
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #102 

## 📝작업 내용

- 도메인명 변경
- 각종 api에 대해 프론트 측 요구에 맞게 리팩토링 / 페이징 처리 및 통폐합 실행
- 집계테이블과 엔티티 재생성 형식으로의 동시성 해결을 시도 -> 조회수 설정, 이 정보들을 이용하여 베스트 리뷰에 대해 선정하고 페이징 처리 

### 스크린샷 (선택)
- 현재 상품과 같은 기획전인 상품들을 연관 상품으로 선택
1. 어느 기획전에 포함된 상품의 uuid 예시
<img width="550" alt="스크린샷 2024-09-21 오후 10 44 46" src="https://github.com/user-attachments/assets/656e54c7-1471-4fdd-897e-a42e7a5f1da3">
<br/>
2. 어느 상품과 같은 기획전에 속한 상품들의 목록(uuid, 관련 상품을 위함)

<img width="550" alt="스크린샷 2024-09-21 오후 10 44 58" src="https://github.com/user-attachments/assets/2f11f056-7aaa-4145-9847-0da36ab3b821">




### 어려운 점,,,
- 각 종 여부(신상, 베스트)에 대해 true, false로 처리하는 ProductFlags라는 엔티티가 존재
- 현재 상품의 경우 등록이 관리자 권한이기에 위 여부에 대해 save하는 과정이 상당히 복잡
- 하나의 row를 입력하기 위해 두개의 컬럼값(베스트여부, 신상여부)를 입력해야되는데, 신상 여부에 대해서만 값을 추출하는것도 jpa나 queryDsl을 통해 처리하는 방법 모두가 모든 상품들을 추출하고 그 중에서 시간에 대해 역정렬(최신순)으로 n개를 뽑는 로직이 row도 아닌 컬럼값 하나를 위한다는 것이 옳지 않은 것 같음 <- 다른 것을 먼저 구현하고 일정 상 여유롭지 않으면 리뷰만 베스트 구현을 하고 상품에 대해서는 true/false를 임의로 입력해야 될 것 같음 
 
