### PR TITLE
fix: 리뷰 등록시 로그인한 회원의 닉네임을 입력받도록 변경

### DIFF
--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductFlags.java
@@ -20,7 +20,9 @@ public class ProductFlags {
 	@Column(nullable = false)
 	private boolean isNew;
 	@Column(nullable = false)
-	private boolean isBest;
+	private boolean isBest; // 전체 상품 중 10개 뽑기
+	@Column(nullable = false)
+	private boolean isLimited;
 	@Column(nullable = false)
 	private String productUuid;
 

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/controller/ReviewController.java
@@ -101,7 +101,7 @@ public class ReviewController {
 		@AuthenticationPrincipal AuthUserDetail authUserDetail) {
 
 		// 로그인된 사용자의 UUID 가져와서 그 사용자의 닉네임 찾기
-		String username = authUserDetail.getUsername();
+		String username = authUserDetail.getNickname();
 
 		// 수정 필요
 		List<UserReviewResponseDto> memberReviewsDto = reviewService.getUserReviews(username);
@@ -171,7 +171,9 @@ public class ReviewController {
 		@AuthenticationPrincipal AuthUserDetail authUserDetail,
 		@RequestBody ReviewRequestVo reviewRequestVo) { // Service 로직에서 UUID 생성하여 저장하므로 vo에서 관련정보를 뺴거나, 서비스 로직에서 제거하기
 
-		reviewService.addReview(ReviewRequestDto.of(reviewRequestVo));
+		String authorName = authUserDetail.getNickname();
+		log.info("authorName: {}", authorName);
+		reviewService.addReview(ReviewRequestDto.of(reviewRequestVo, authorName));
 
 		return new BaseResponse<>(
 			BaseResponseStatus.SUCCESS
@@ -180,22 +182,16 @@ public class ReviewController {
 
 	@PutMapping("/{reviewUuid}")
 	@Operation(summary = "리뷰 수정", description = "기존에 작성된 리뷰를 수정합니다.")
-	public CommonResponseEntity<Void> updateReview(
+	public BaseResponse<Void> updateReview(
 		@PathVariable String reviewUuid,
 		@AuthenticationPrincipal AuthUserDetail authUserDetail,
 		@RequestBody ReviewModifyRequestVo reviewModifyRequestVo) {
 
-		ReviewModifyRequestDto reviewModifyRequestDto = ReviewModifyRequestDto.builder()
-			.content(reviewModifyRequestVo.getContent())
-			.reviewScore(reviewModifyRequestVo.getReviewScore())
-			.build();
+		// authorName이 같으먄 수정가능
+		reviewService.modifyReview(ReviewModifyRequestDto.of(reviewModifyRequestVo), reviewUuid);
 
-		reviewService.modifyReview(reviewModifyRequestDto, reviewUuid);
-
-		return new CommonResponseEntity<>(
-			HttpStatus.OK,
-			CommonResponseMessage.SUCCESS.getMessage(),
-			null
+		return new BaseResponse<>(
+			BaseResponseStatus.SUCCESS
 		);
 
 	}

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewModifyRequestDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewModifyRequestDto.java
@@ -1,14 +1,26 @@
 package starbucks3355.starbucksServer.domainReview.dto.in;
 
-import java.time.LocalDateTime;
-
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import starbucks3355.starbucksServer.domainReview.vo.in.ReviewModifyRequestVo;
 
 @Getter
-@Builder
+@NoArgsConstructor
 public class ReviewModifyRequestDto {
 	private String content;
 	private Integer reviewScore;
-	private LocalDateTime regDate, modDate;
+
+	@Builder
+	public ReviewModifyRequestDto(String content, Integer reviewScore) {
+		this.content = content;
+		this.reviewScore = reviewScore;
+	}
+
+	public static ReviewModifyRequestDto of(ReviewModifyRequestVo reviewModifyRequestVo) {
+		return ReviewModifyRequestDto.builder()
+			.content(reviewModifyRequestVo.getContent())
+			.reviewScore(reviewModifyRequestVo.getReviewScore())
+			.build();
+	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewRequestDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/dto/in/ReviewRequestDto.java
@@ -35,12 +35,12 @@ public class ReviewRequestDto {
 			.build();
 	}
 
-	public static ReviewRequestDto of(ReviewRequestVo reviewRequestVo) {
+	public static ReviewRequestDto of(ReviewRequestVo reviewRequestVo, String authorName) {
 		return ReviewRequestDto.builder()
 			.content(reviewRequestVo.getContent())
 			.reviewScore(reviewRequestVo.getReviewScore())
 			.productUuid(reviewRequestVo.getProductUuid())
-			.authorName(reviewRequestVo.getAuthorName())
+			.authorName(authorName)
 			.build();
 	}
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/vo/in/ReviewModifyRequestVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/vo/in/ReviewModifyRequestVo.java
@@ -1,7 +1,5 @@
 package starbucks3355.starbucksServer.domainReview.vo.in;
 
-import java.time.LocalDateTime;
-
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,5 +8,5 @@ import lombok.Getter;
 public class ReviewModifyRequestVo {
 	private String content;
 	private Integer reviewScore;
-	private LocalDateTime regDate, modDate;
+
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/vo/in/ReviewRequestVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/vo/in/ReviewRequestVo.java
@@ -7,7 +7,7 @@ public class ReviewRequestVo {
 	private String content;
 	private Integer reviewScore;
 	private String productUuid;
-	private String authorName; // 액세스 토큰에서 받은 uuid값을 가공해서 삽입 <- 닉네임으로 할 경우 변경시 문제 발생
+	// private String authorName; // 액세스 토큰에서 받은 uuid값을 가공해서 삽입 <- 닉네임으로 할 경우 변경시 문제 발생
 	// 회원이 구매한 '상품'에 대한 리뷰
 	// private String memberUuid; // 미확실 필드: 시큐리티의 토큰처리에 따라 사용여부 결정
 }

--- a/src/main/java/starbucks3355/starbucksServer/vendor/entity/ProductByCategoryList.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/entity/ProductByCategoryList.java
@@ -1,0 +1,25 @@
+package starbucks3355.starbucksServer.vendor.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@ToString
+public class ProductByCategoryList {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String majorCategoryName;
+
+	private String middleCategoryName;
+
+	private String productUuid;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #104 

## 📝작업 내용

- 리뷰 등록 api에 대해 작성자의 uuid 말고 닉네임을 받도록 수정
- 같은 기획전에 포함된 상품 목록 조회시 반환되는 응답데이터에 대해 필드명 수정