### PR TITLE
feat: 상품 기획전 이름 목록 조회 및 상품 태그 목록 조회(QueryDsl 이용한 중복 처리)

### DIFF
--- a/src/main/java/starbucks3355/starbucksServer/common/entity/BaseResponseStatus.java
+++ b/src/main/java/starbucks3355/starbucksServer/common/entity/BaseResponseStatus.java
@@ -39,7 +39,6 @@ public enum BaseResponseStatus {
 	DUPLICATE_ID(HttpStatus.BAD_REQUEST, false, 415, "id 값이 중복됩니다."),
 	WRONG_FILE_TYPE(HttpStatus.BAD_REQUEST, false, 418, "잘못된 파일 형식입니다."),
 
-
 	/**
 	 * 900: 기타 에러
 	 */
@@ -88,6 +87,8 @@ public enum BaseResponseStatus {
 	NO_EXIST_PRODUCT_DETAIL(HttpStatus.NOT_FOUND, false, 3006, "해당 상품의 상세정보가 존재하지 않습니다."),
 	FAILED_TO_ADD_S3(HttpStatus.INTERNAL_SERVER_ERROR, false, 3007, "AWS S3에 이미지 저장을 실패했습니다."),
 	NO_EXIST_S3_IMAGE(HttpStatus.NOT_FOUND, false, 3008, "AWS S3에 해당 이미지가 존재하지 않습니다."),
+	NO_EXIST_IMAGE(HttpStatus.NOT_FOUND, false, 3009, "해당 이미지가 존재하지 않습니다."),
+	NO_EXIST_TAG(HttpStatus.NOT_FOUND, false, 3010, "태그 정보가 존재하지 않습니다."),
 
 	/**
 	 * 4000: comment service error

--- a/src/main/java/starbucks3355/starbucksServer/domainImage/controller/ImageController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainImage/controller/ImageController.java
@@ -42,6 +42,16 @@ public class ImageController {
 	) {
 		List<ImageResponseDto> imageDtoList = imageService.getImages(otherUuid);
 
+		if (imageDtoList.isEmpty()) {
+			return new BaseResponse<>(
+				HttpStatus.NO_CONTENT,
+				BaseResponseStatus.NO_EXIST_IMAGE.isSuccess(),
+				BaseResponseStatus.NO_EXIST_IMAGE.getMessage(),
+				BaseResponseStatus.NO_EXIST_IMAGE.getCode(),
+				null
+			);
+		}
+
 		return new BaseResponse<>(
 			HttpStatus.OK,
 			BaseResponseStatus.SUCCESS.isSuccess(),

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/controller/ProductController.java
@@ -30,6 +30,7 @@ import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountResponse
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductFlagsResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductTagResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductsResponseDto;
 import starbucks3355.starbucksServer.domainProduct.service.ProductService;
 import starbucks3355.starbucksServer.domainProduct.vo.request.ProductRequestVo;
@@ -37,6 +38,7 @@ import starbucks3355.starbucksServer.domainProduct.vo.response.DiscountResponseV
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductDetailsPriceResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductFlagsResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductResponseVo;
+import starbucks3355.starbucksServer.domainProduct.vo.response.ProductTagResponseVo;
 import starbucks3355.starbucksServer.domainProduct.vo.response.ProductsResponseVo;
 import starbucks3355.starbucksServer.vendor.service.ProductListByCategoryService;
 import starbucks3355.starbucksServer.vendor.vo.out.CategoryAndCountOfSearchedProductListResponseVo;
@@ -253,8 +255,26 @@ public class ProductController {
 		@RequestParam(value = "page", required = false) Integer page
 	) {
 		return new BaseResponse<>(
+			HttpStatus.OK,
+			BaseResponseStatus.SUCCESS.isSuccess(),
+			BaseResponseStatus.SUCCESS.getMessage(),
+			BaseResponseStatus.SUCCESS.getCode(),
 			productListByCategoryService.getProductByCategoryOfSearchedProducts(
 				productUuidList, topCategoryName, lastId, pageSize, page)
+		);
+	}
+
+	@GetMapping("/tagList")
+	@Operation(summary = "상품 태그 목록 조회")
+	public BaseResponse<List<ProductTagResponseVo>> getTagList() {
+		return new BaseResponse<>(
+			HttpStatus.OK,
+			BaseResponseStatus.SUCCESS.isSuccess(),
+			BaseResponseStatus.SUCCESS.getMessage(),
+			BaseResponseStatus.SUCCESS.getCode(),
+			productService.getTagList().stream()
+				.map(ProductTagResponseDto::toResponseVo)
+				.toList()
 		);
 	}
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductTagResponseDto.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/dto/response/ProductTagResponseDto.java
@@ -1,0 +1,36 @@
+package starbucks3355.starbucksServer.domainProduct.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import starbucks3355.starbucksServer.domainProduct.entity.ProductTag;
+import starbucks3355.starbucksServer.domainProduct.vo.response.ProductTagResponseVo;
+
+@Getter
+@NoArgsConstructor
+public class ProductTagResponseDto {
+	String tagName;
+
+	@Builder
+	public ProductTagResponseDto(String tagName) {
+		this.tagName = tagName;
+	}
+
+	public ProductTagResponseVo toResponseVo() {
+		return ProductTagResponseVo.builder()
+			.tagName(tagName)
+			.build();
+	}
+
+	public static ProductTagResponseDto from(ProductTag productTag) {
+		return ProductTagResponseDto.builder()
+			.tagName(productTag.getTagName())
+			.build();
+	}
+
+	public static ProductTagResponseDto fromName(String tagName) {
+		return ProductTagResponseDto.builder()
+			.tagName(tagName)
+			.build();
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductTagRepositoryCustom.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductTagRepositoryCustom.java
@@ -1,0 +1,12 @@
+package starbucks3355.starbucksServer.domainProduct.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductTagResponseDto;
+
+@Repository
+public interface ProductTagRepositoryCustom {
+	List<ProductTagResponseDto> getTagList();
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductTagRepositoryCustomImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/repository/ProductTagRepositoryCustomImpl.java
@@ -1,0 +1,31 @@
+package starbucks3355.starbucksServer.domainProduct.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductTagResponseDto;
+import starbucks3355.starbucksServer.domainProduct.entity.QProductTag;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductTagRepositoryCustomImpl implements ProductTagRepositoryCustom {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<ProductTagResponseDto> getTagList() {
+		QProductTag productTag = QProductTag.productTag;
+
+		List<String> productTagList = jpaQueryFactory
+			.selectDistinct(productTag.tagName)
+			.from(productTag)
+			.fetch();
+
+		return productTagList.stream()
+			.map(ProductTagResponseDto::fromName)
+			.toList();
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductService.java
@@ -1,5 +1,7 @@
 package starbucks3355.starbucksServer.domainProduct.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Slice;
 
 import starbucks3355.starbucksServer.common.utils.CursorPage;
@@ -8,6 +10,7 @@ import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountResponse
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductFlagsResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductTagResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductsResponseDto;
 
 public interface ProductService {
@@ -45,6 +48,8 @@ public interface ProductService {
 		Integer pageSize,
 		Integer page
 	);
+
+	List<ProductTagResponseDto> getTagList();
 
 	void addRecentlyViewed(String memberUuid, String productUuid);
 

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/service/ProductServiceImpl.java
@@ -1,6 +1,7 @@
 package starbucks3355.starbucksServer.domainProduct.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -20,6 +21,7 @@ import starbucks3355.starbucksServer.domainProduct.dto.response.DiscountResponse
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductDetailsPriceResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductFlagsResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductResponseDto;
+import starbucks3355.starbucksServer.domainProduct.dto.response.ProductTagResponseDto;
 import starbucks3355.starbucksServer.domainProduct.dto.response.ProductsResponseDto;
 import starbucks3355.starbucksServer.domainProduct.entity.Product;
 import starbucks3355.starbucksServer.domainProduct.repository.DiscountRepository;
@@ -27,6 +29,7 @@ import starbucks3355.starbucksServer.domainProduct.repository.FlagsRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductDetailsRepository;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductListRepositoryCustom;
 import starbucks3355.starbucksServer.domainProduct.repository.ProductRepository;
+import starbucks3355.starbucksServer.domainProduct.repository.ProductTagRepositoryCustom;
 
 @Service
 @Slf4j
@@ -39,6 +42,8 @@ public class ProductServiceImpl implements ProductService {
 	private final FlagsRepository flagsRepository;
 	private final ProductListRepositoryCustom productListRepositoryCustom;
 	private final RedisTemplate<String, String> redisTemplate;
+
+	private final ProductTagRepositoryCustom productTagRepositoryCustom;
 
 	private static final String RECENTLY_VIEWED_PREFIX = "recently_viewed:";
 	private static final int MAX_SIZE = 40;
@@ -69,9 +74,20 @@ public class ProductServiceImpl implements ProductService {
 
 	@Override
 	public ProductResponseDto getProduct(String productUuid) {
+		log.info("상품 조회 요청: UUID = {}", productUuid); // 요청한 UUID 로그
 
-		return ProductResponseDto.from(productRepository.findByProductUuid(productUuid)
-			.orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_PRODUCT)));
+		Optional<Product> productOptional = productRepository.findByProductUuid(productUuid);
+
+		if (productOptional.isPresent()) {
+			log.info("상품 조회 성공: {}", productOptional.get()); // 상품 정보 로그
+			return ProductResponseDto.from(productOptional.get());
+		} else {
+			log.warn("상품 조회 실패: 존재하지 않는 UUID = {}", productUuid); // 존재하지 않는 경우 로그
+			throw new BaseException(BaseResponseStatus.NO_EXIST_PRODUCT);
+		}
+
+		// return ProductResponseDto.from(productRepository.findByProductUuid(productUuid)
+		// 	.orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_PRODUCT)));
 
 	}
 
@@ -116,6 +132,11 @@ public class ProductServiceImpl implements ProductService {
 			.page(page)
 			.build();
 
+	}
+
+	@Override
+	public List<ProductTagResponseDto> getTagList() {
+		return productTagRepositoryCustom.getTagList();
 	}
 
 	@Override

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductTagResponseVo.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/vo/response/ProductTagResponseVo.java
@@ -1,0 +1,16 @@
+package starbucks3355.starbucksServer.domainProduct.vo.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductTagResponseVo {
+	String tagName;
+
+	@Builder
+	public ProductTagResponseVo(String tagName) {
+		this.tagName = tagName;
+	}
+}

--- a/src/main/java/starbucks3355/starbucksServer/domainPromotion/controller/PromotionController.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainPromotion/controller/PromotionController.java
@@ -29,7 +29,7 @@ public class PromotionController {
 	private final PromotionService promotionService;
 
 	@GetMapping("/list")
-	@Operation(summary = "기획전 uuid 목록 조회")
+	@Operation(summary = "기획전 uuid 조회")
 	public BaseResponse<List<PromotionResponseVo>> getPromotionList() {
 
 		List<PromotionResponseDto> promotionUuidList = promotionService.getPromotionUuidList();
@@ -59,6 +59,22 @@ public class PromotionController {
 			BaseResponseStatus.SUCCESS.getMessage(),
 			BaseResponseStatus.SUCCESS.getCode(),
 			promotionName.dtoToResponseVo()
+		);
+	}
+
+	@GetMapping("/nameList")
+	@Operation(summary = "기획전 이름 목록 조회")
+	public BaseResponse<List<PromotionNameResponseVo>> getPromotionNameList() {
+		List<PromotionNameResponseDto> promotionNameList = promotionService.getPromotionNameList();
+
+		return new BaseResponse<>(
+			HttpStatus.OK,
+			BaseResponseStatus.SUCCESS.isSuccess(),
+			BaseResponseStatus.SUCCESS.getMessage(),
+			BaseResponseStatus.SUCCESS.getCode(),
+			promotionNameList.stream()
+				.map(PromotionNameResponseDto::dtoToResponseVo)
+				.toList()
 		);
 	}
 

--- a/src/main/java/starbucks3355/starbucksServer/domainPromotion/repository/PromotionRepositoryCustom.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainPromotion/repository/PromotionRepositoryCustom.java
@@ -15,4 +15,6 @@ public interface PromotionRepositoryCustom {
 	PromotionNameResponseDto getPromotionName(String promotionUuid);
 
 	// List<PromotionProductResponseDto> getPromotionProductList(String promotionUuid);
+
+	List<PromotionNameResponseDto> getPromotionNameList();
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainPromotion/repository/PromotionRepositoryCustomImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainPromotion/repository/PromotionRepositoryCustomImpl.java
@@ -10,6 +10,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import starbucks3355.starbucksServer.domainPromotion.dto.out.PromotionNameResponseDto;
 import starbucks3355.starbucksServer.domainPromotion.dto.out.PromotionResponseDto;
+import starbucks3355.starbucksServer.domainPromotion.entity.Promotion;
 import starbucks3355.starbucksServer.domainPromotion.entity.QPromotion;
 
 @RequiredArgsConstructor
@@ -46,6 +47,20 @@ public class PromotionRepositoryCustomImpl implements PromotionRepositoryCustom 
 			.fetchOne();
 
 		return promotionName == null ? null : new PromotionNameResponseDto(promotionName);
+	}
+
+	@Override
+	public List<PromotionNameResponseDto> getPromotionNameList() {
+		QPromotion promotion = QPromotion.promotion;
+
+		List<Promotion> promotionList = jpaQueryFactory
+			.selectDistinct(promotion)
+			.from(promotion)
+			.fetch();
+
+		return promotionList.stream()
+			.map(PromotionNameResponseDto::from)
+			.toList();
 	}
 
 	// @Override

--- a/src/main/java/starbucks3355/starbucksServer/domainPromotion/service/PromotionService.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainPromotion/service/PromotionService.java
@@ -12,4 +12,6 @@ public interface PromotionService {
 
 	// List<PromotionProductResponseDto> getPromotionProductList(String promotionUuid);
 
+	List<PromotionNameResponseDto> getPromotionNameList();
+
 }

--- a/src/main/java/starbucks3355/starbucksServer/domainPromotion/service/PromotionServiceImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainPromotion/service/PromotionServiceImpl.java
@@ -27,6 +27,11 @@ public class PromotionServiceImpl implements PromotionService {
 		return promotionRepositoryCustom.getPromotionName(promotionUuid);
 	}
 
+	@Override
+	public List<PromotionNameResponseDto> getPromotionNameList() {
+		return promotionRepositoryCustom.getPromotionNameList();
+	}
+
 	// @Override
 	// public List<PromotionProductResponseDto> getPromotionProductList(String promotionUuid) {
 	// 	return promotionRepositoryCustom.getPromotionProductList(promotionUuid);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #149 

## 📝작업 내용

- 상품 태그 이름 목록 조회 api 생성
- 상품 기획전 이름 목록 조회 api 생성
- BaseReponseStatus 의 메세지 추가


### 이미지


<img width="474" alt="스크린샷 2024-09-26 오후 12 24 55" src="https://github.com/user-attachments/assets/ef678047-4b81-4f52-935a-3a7b98d56962">
<br/>
<img width="441" alt="스크린샷 2024-09-26 오후 12 25 15" src="https://github.com/user-attachments/assets/2c86aa92-5d89-4c22-bf60-4f6b28b5ec0d">

