### PR TITLE
 fix: 기본 배송지 조회 예외 터져도 요청 성공

### DIFF
--- a/src/main/java/starbucks3355/starbucksServer/shipping/controller/ShippingController.java
+++ b/src/main/java/starbucks3355/starbucksServer/shipping/controller/ShippingController.java
@@ -118,17 +118,30 @@ public class ShippingController {
 	public BaseResponse<ShippingBaseResponseVo> getBaseDelivery(
 		//밑에 @쓰면 AuthUserDetail것을 가져와서 사용 가능
 		@AuthenticationPrincipal AuthUserDetail authUserDetail) {
+		try {
+			//인증된 사용자의 uuid를 가져와서 사용 가능
+			String userUuid = authUserDetail.getUuid();
+			ShippingBaseResponseDto shippingBaseResponseDto = shippingService.getBaseShippingAddress(userUuid);
 
-		//인증된 사용자의 uuid를 가져와서 사용 가능
-		String userUuid = authUserDetail.getUuid();
-		ShippingBaseResponseDto shippingBaseResponseDto = shippingService.getBaseShippingAddress(userUuid);
+			ShippingBaseResponseVo responseVo = null;
+			if (shippingBaseResponseDto != null) {
+				responseVo = shippingBaseResponseDto.toVo();
+			}
+			return new BaseResponse<>(
+				HttpStatus.OK,
+				SUCCESS.isSuccess(),
+				SUCCESS.getMessage(),
+				SUCCESS.getCode(),
+				responseVo);
 
-		return new BaseResponse<>(
-			HttpStatus.OK,
-			SUCCESS.isSuccess(),
-			SUCCESS.getMessage(),
-			SUCCESS.getCode(),
-			shippingBaseResponseDto.toVo());
+		} catch (Exception e) {
+			return new BaseResponse<>(
+				HttpStatus.OK,
+				SUCCESS.isSuccess(),
+				SUCCESS.getMessage(),
+				SUCCESS.getCode(),
+				null);
+		}
 	}
 
 	@PutMapping("/base/{deliveryId}/set-default")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #147 
## 📝작업 내용

> 기본 배송지 조회 할때 값이 널 값이라도 무조건 성공하고 return 값 null로 보내기

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

