### PR TITLE
fix: ehcache를 통해 2차캐싱 처리를 함으로써 조회성능 약 200배 향상

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,10 @@ dependencies {
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-
+    // Hibernate 2차 캐시
+    implementation 'org.ehcache:ehcache:3.10.8' // Ehcache 3.x
+    implementation 'javax.cache:cache-api:1.1.1' // JCache (JSR-107) API 의존성
+    implementation 'org.hibernate.orm:hibernate-jcache:6.1.7.Final' // Hibernate와 JCache 통합 모듈 (Hibernate 6.x)
 }
 
 tasks.named('test') {

--- a/src/main/java/starbucks3355/starbucksServer/domainCart/entity/Cart.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainCart/entity/Cart.java
@@ -1,5 +1,8 @@
 package starbucks3355.starbucksServer.domainCart.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -15,6 +18,7 @@ import starbucks3355.starbucksServer.common.entity.BaseEntity;
 @Getter
 @NoArgsConstructor
 @ToString
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class Cart extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/starbucks3355/starbucksServer/domainImage/entity/Image.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainImage/entity/Image.java
@@ -1,5 +1,8 @@
 package starbucks3355.starbucksServer.domainImage.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -22,6 +25,7 @@ import lombok.ToString;
 @Table(name = "image", indexes = {
 	@Index(name = "idx_other_uuid", columnList = "otherUuid")
 })
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class Image {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/Product.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/Product.java
@@ -1,5 +1,8 @@
 package starbucks3355.starbucksServer.domainProduct.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,6 +23,7 @@ import starbucks3355.starbucksServer.common.entity.BaseEntity;
 @Table(name = "product_details", indexes = {
 	@Index(name = "idx_product_uuid", columnList = "productUuid")
 })
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class Product extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductDetails.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainProduct/entity/ProductDetails.java
@@ -1,5 +1,8 @@
 package starbucks3355.starbucksServer.domainProduct.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,6 +29,7 @@ import lombok.ToString;
 @Table(name = "product_details", indexes = {
 	@Index(name = "idx_product_uuid", columnList = "productUuid")
 })
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class ProductDetails { // Options
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/starbucks3355/starbucksServer/domainPromotion/entity/Promotion.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainPromotion/entity/Promotion.java
@@ -1,5 +1,8 @@
 package starbucks3355.starbucksServer.domainPromotion.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -14,6 +17,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @Getter
 @ToString
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class Promotion {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/entity/Review.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/entity/Review.java
@@ -1,5 +1,8 @@
 package starbucks3355.starbucksServer.domainReview.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,6 +23,7 @@ import starbucks3355.starbucksServer.common.entity.BaseEntity;
 	@jakarta.persistence.Index(name = "idx_product_uuid", columnList = "productUuid"),
 	@jakarta.persistence.Index(name = "idx_author_name", columnList = "authorName")
 })
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class Review extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/starbucks3355/starbucksServer/domainReview/entity/ReviewAggregate.java
+++ b/src/main/java/starbucks3355/starbucksServer/domainReview/entity/ReviewAggregate.java
@@ -1,5 +1,8 @@
 package starbucks3355.starbucksServer.domainReview.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -14,6 +17,7 @@ import lombok.ToString;
 @Getter
 @NoArgsConstructor
 @ToString
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class ReviewAggregate {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/starbucks3355/starbucksServer/vendor/entity/ProductByCategoryList.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/entity/ProductByCategoryList.java
@@ -1,5 +1,8 @@
 package starbucks3355.starbucksServer.vendor.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,9 +18,9 @@ import lombok.ToString;
 @Getter
 @ToString
 @Table(name = "product_by_category_list", indexes = {
-	@Index(name = "idx_top_category_name", columnList = "topCategoryName"),
-	@Index(name = "idx_middle_category_name", columnList = "middleCategoryName")
+	@Index(name = "idx_product_uuid", columnList = "productUuid")
 })
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class ProductByCategoryList {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/starbucks3355/starbucksServer/vendor/entity/ProductByPromotionList.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/entity/ProductByPromotionList.java
@@ -1,5 +1,8 @@
 package starbucks3355.starbucksServer.vendor.entity;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "product_by_promotion_list", indexes = {
 	@Index(name = "idx_product_uuid", columnList = "productUuid")
 })
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class ProductByPromotionList {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/starbucks3355/starbucksServer/vendor/repository/ProductListByCategoryRepositoryCustomImpl.java
+++ b/src/main/java/starbucks3355/starbucksServer/vendor/repository/ProductListByCategoryRepositoryCustomImpl.java
@@ -84,7 +84,7 @@ public class ProductListByCategoryRepositoryCustomImpl implements ProductListByC
 				)
 			)
 			.from(product)
-			.leftJoin(categoryList).on(product.productUuid.eq(categoryList.productUuid))// 상품과 카테고리 조인
+			.innerJoin(categoryList).on(product.productUuid.eq(categoryList.productUuid)).fetchJoin()// 상품과 카테고리 조인
 			.where(product.productUuid.in(productUuidList)) // 주어진 UUID 리스트로 필터링
 			.groupBy(categoryList.topCategoryName) // 카테고리별로 그룹화
 			.fetch();

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -1,0 +1,19 @@
+<config xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns='http://www.ehcache.org/v3'
+        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core.xsd">
+
+    <cache alias="com.example.Product">
+        <expiry>
+            <ttl unit="seconds">600</ttl>
+        </expiry>
+        <heap unit="entries">1000</heap>
+    </cache>
+
+    <cache alias="com.example.ProductDetails">
+        <expiry>
+            <ttl unit="seconds">600</ttl>
+        </expiry>
+        <heap unit="entries">1000</heap>
+    </cache>
+
+</config>

--- a/src/test/java/starbucks3355/starbucksServer/domainProduct/repository/ProductRepositoryTest.java
+++ b/src/test/java/starbucks3355/starbucksServer/domainProduct/repository/ProductRepositoryTest.java
@@ -37,7 +37,7 @@ public class ProductRepositoryTest {
 	// 		productRepository.save(product);
 	//
 	// 	});
-  
+
 	// 	long endTime = System.currentTimeMillis(); // 종료 시간 기록
 	// 	long duration = endTime - startTime; // 실행 시간 계산
 	//
@@ -75,7 +75,6 @@ public class ProductRepositoryTest {
 	// 	CursorPage<String> searchedProductList = productListRepositoryCustom.getSearchedProductList("장우산", 20L, 20,
 	// 		1);
 	// 	log.info(searchedProductList.toString());
-
 	//
 	// 	long endTime = System.currentTimeMillis(); // 종료 시간 기록
 	// 	long duration = endTime - startTime; // 실행 시간 계산
@@ -90,9 +89,9 @@ public class ProductRepositoryTest {
 	//
 	// 	// 실행 시간 로그 출력
 	// 	log.info("pageable 통한 상품 리스트 조회 완료. 실행 시간: " + durationPaging + "ms");
-
+	//
 	// 	System.out.println("상품 더미 데이터 삽입 완료. 실행 시간: " + duration + "ms");
-
+	//
 	// }
 
 	// 베스트 리뷰조회에 대해 jpa 와 querydsl로 구현한 것을 비교해보기


### PR DESCRIPTION
## #️⃣연관된 이슈

- 이슈번호 없음
- 조회성능이 너무 느림 -> ec2로그를 확인하니 N+1 발생 -> api의 연달은 호출로 인한 현상
- 관계를 맺지 않았고 특정 컬럼의 값으로 연결되어있음, 현재 프론트 팀원의 업무가 불가능한 상황이며, 응답데이터의 변경 처리 없이는 fetch join 적용이 어려움
- 고민 끝에 2차 캐시 대한 방법을 찾아냄 -> ehcache 적용 -> 테스트에서 jpa 메서드를 쓴 Product엔티티 List 조회가 기존의 평균 23XX ms에서 1x ms로 약 200배 성능개선을 이뤄냄 
- 이 방법이 100퍼 해결책일지는 모르겠으나 연관이 있을 것 같아 pr 생성